### PR TITLE
Added LibZwaveIp and the required dependency 

### DIFF
--- a/ZipApplication/ZipApplication.csproj
+++ b/ZipApplication/ZipApplication.csproj
@@ -86,6 +86,8 @@
     <Compile Include="ZipControllerDiscoverService.cs" />
     <Compile Include="ZipFrameClient.cs" />
     <Compile Include="ZipFrameLayer.cs" />
+    <Compile Include="LibZwaveIpTransportClient.cs" />
+    <Compile Include="LibZwaveIpTransportLayer.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Utils\Utils.csproj">
@@ -114,6 +116,11 @@
       <Link>ziptrans64.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Renci.SshNet.Async">
+      <Version>1.4.0</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Z-Wave Automatic Test system uses LibZwaveIp to handle raspberryPi communication through ssh. 
I decided to add  the functionality instead of removing it since it was not  clear it was unwanted from z-wave-automatic-test-system perspective.

This changed was prompted upon trying to build https://github.com/Z-Wave-Alliance/z-wave-automated-test-system
https://github.com/Z-Wave-Alliance/z-wave-automated-test-system/issues/8

<!--
SPDX-License-Identifier: BSD-3-Clause
SPDX-FileCopyrightText: 2024 Z-Wave Alliance
-->

<!--
  This is a reminder that all Z-Wave Alliance activities are subject to strict
  compliance with the Z-Wave Antitrust Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/56)
  and IPR Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/43).
  Each individual contributor is responsible to know the contents of these documents
  and to comply with Policies. Copies of all governing documents are available on Causeway.

  Please, DO NOT DELETE ANY TEXT from this template unless instructed!
-->

## Related issue
<!--
  Mention the related issue as described in https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

## Change
<!--
  Describe your changes below.
-->


## Type of change
<!--
  What type of change does your PR introduce?
-->

- [X] New Feature
- [ ] Bug fix
- [ ] Editorial change
- [ ] Refactoring
- [ ] DevOps
- [ ] Breaking
- [ ] Other: (please describe)


## Checklist
<!--
  Please put an `x` in each box to make sure you follow the OSWG Guidelines.
-->

- [X] I have followed the [Contribution Guidelines][contribution-guidelines]
- [X] I agree to the [Developer Certificate of Origin][dco]
- [X] I have cleaned up my commits

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/contribution_guidelines.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
