### PR TITLE
Prevent GitHub build action from running on every push, even before a pull request (PR) was created. Ensure that the action is still running on every new push for a branch where a PR exists.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,20 +1,19 @@
 # YAML -*- mode: yaml; tab-width: 2; indent-tabs-mode: nil; coding: utf-8 -*-
 # SPDX-License-Identifier: BSD-3-Clause
-# SPDX-FileCopyrightText: 2024 Z-Wave Alliance
-# SPDX-FileCopyrightText: 2025 Trident IoT, LLC <https://www.tridentiot.com>
+# SPDX-FileCopyrightText: Z-Wave Alliance https://z-wavealliance.org
+# SPDX-FileCopyrightText: Trident IoT, LLC https://www.tridentiot.com
 
 # This workflow requires a secret named GH_ZWAVE_ACCESS_TOKEN that contains
 # a Personal Access Token with read-only permissions to "Contents".
 name: Build and Test Z-Wave Tools Core
 
 on:
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - main
   workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize # Runs on each push when pull request exists.
 
 jobs:
   legal-check:


### PR DESCRIPTION
<!--
SPDX-License-Identifier: BSD-3-Clause
SPDX-FileCopyrightText: 2024 Z-Wave Alliance
-->

<!--
  This is a reminder that all Z-Wave Alliance activities are subject to strict
  compliance with the Z-Wave Antitrust Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/56)
  and IPR Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/43).
  Each individual contributor is responsible to know the contents of these documents
  and to comply with Policies. Copies of all governing documents are available on Causeway.

  Please, DO NOT DELETE ANY TEXT from this template unless instructed!
-->

## Related issue
<!--
  Mention the related issue as described in https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

## Change
<!--
  Describe your changes below.
-->

Prevent GitHub build action from running on every push, even before a pull request (PR) was created. Ensure that the action is still running on every new push for a branch where a PR exists.

## Type of change
<!--
  What type of change does your PR introduce?
-->

- [ ] New Feature
- [x] Bug fix
- [ ] Editorial change
- [ ] Refactoring
- [ ] DevOps
- [ ] Breaking
- [ ] Other: (please describe)


## Checklist
<!--
  Please put an `x` in each box to make sure you follow the OSWG Guidelines.
-->

- [x] I have followed the [Contribution Guidelines][contribution-guidelines]
- [x] I agree to the [Developer Certificate of Origin][dco]
- [x] I have cleaned up my commits

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/contribution_guidelines.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
