### PR TITLE
Fixed missing license information in files generated from zwave.xml for use in ZATS.

### DIFF
--- a/ZWaveXml/HeaderGenerator/CSharpGenerator.cs
+++ b/ZWaveXml/HeaderGenerator/CSharpGenerator.cs
@@ -76,7 +76,7 @@ namespace ZWave.Xml.HeaderGenerator
                 using (FileStream fs = new FileStream(Path.Combine(folder ?? "", name + ".cs"), FileMode.Create))
                 {
                     StreamWriter sw = new StreamWriter(fs) { NewLine = LINE_ENDING };
-                    GenerateLicenseInfo(sw, isZats);
+                    GenerateLicenseInfo(sw);
                     if (cmdClass.Command != null && cmdClass.Command.Count > 0)
                     {
                         GenerateUsingSection(sw);
@@ -114,13 +114,10 @@ namespace ZWave.Xml.HeaderGenerator
             }
         }
 
-        private static void GenerateLicenseInfo(StreamWriter sw, bool isZats)
+        private static void GenerateLicenseInfo(StreamWriter sw)
         {
-            if (!isZats)
-            { 
-                sw.WriteLine($"/// SPDX-License-Identifier: BSD-3-Clause");
-                sw.WriteLine($"/// SPDX-FileCopyrightText: Z-Wave-Alliance https://z-wavealliance.org");
-            }
+            sw.WriteLine($"/// SPDX-License-Identifier: BSD-3-Clause");
+            sw.WriteLine($"/// SPDX-FileCopyrightText: Z-Wave-Alliance https://z-wavealliance.org");
         }
 
         private static void GenerateProperties(TextWriter sw, Command cmd)
@@ -1019,7 +1016,7 @@ namespace ZWave.Xml.HeaderGenerator
             using (FileStream fs = new FileStream(Path.Combine(folder ?? "", expStrName), FileMode.Create))
             {
                 StreamWriter sw = new StreamWriter(fs) { NewLine = LINE_ENDING };
-                GenerateLicenseInfo(sw, isZats);
+                GenerateLicenseInfo(sw);
                 sw.WriteLine("/// Generated file from the Z-Wave XML Editor.");
                 GenerateNamespaceBegin(sw, isZats);
 


### PR DESCRIPTION
<!--
SPDX-License-Identifier: BSD-3-Clause
SPDX-FileCopyrightText: 2024 Z-Wave Alliance
-->

<!--
  This is a reminder that all Z-Wave Alliance activities are subject to strict
  compliance with the Z-Wave Antitrust Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/56)
  and IPR Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/43).
  Each individual contributor is responsible to know the contents of these documents
  and to comply with Policies. Copies of all governing documents are available on Causeway.

  Please, DO NOT DELETE ANY TEXT from this template unless instructed!
-->

## Related issue
<!--
  Mention the related issue as described in https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

## Change
<!--
  Describe your changes below.
-->

Fixed missing license information in files generated from zwave.xml for use in ZATS.

## Type of change
<!--
  What type of change does your PR introduce?
-->

- [ ] New Feature
- [x] Bug fix
- [ ] Editorial change
- [ ] Refactoring
- [ ] DevOps
- [ ] Breaking
- [ ] Other: (please describe)


## Checklist
<!--
  Please put an `x` in each box to make sure you follow the OSWG Guidelines.
-->

- [x] I have followed the [Contribution Guidelines][contribution-guidelines]
- [x] I agree to the [Developer Certificate of Origin][dco]
- [x] I have cleaned up my commits

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/contribution_guidelines.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
