### PR TITLE
Z/H/CHGenerator: Remove gen timestamp for reproducibility

### DIFF
--- a/ZWaveXml/HeaderGenerator/CHGenerator.cs
+++ b/ZWaveXml/HeaderGenerator/CHGenerator.cs
@@ -186,7 +186,7 @@ namespace ZWave.Xml.HeaderGenerator
         private void Generate_Info()
         {
             Sw.WriteLine(LineComment + "This file is auto generated. Do not edit it manually!");
-            Sw.WriteLine(LineComment + "Generated on: " + DateTime.Now);
+            Sw.WriteLine(LineComment + "Generated with: https://github.com/Z-Wave-Alliance/z-wave-xml-tools");
         }
 
         private void Generate_Defines(IEnumerable<BasicDevice> basicDeviceList)


### PR DESCRIPTION
The change remove the timestamp to enable reproducible builds.

It will help to automate xml updates in consuming projects, they can be re-generated at buildtime, this timestamp info is adding noise.

By the way the ref of the tool is added.

One improvement to consider is to add git-describe of inputs files (and tool) in header, but it can also generate noise too, we lived without that so far.

Relate-to: https://github.com/Z-Wave-Alliance/z-wave-stack/issues/88
Relate-to: https://github.com/Z-Wave-Alliance/z-wave-xml-tools/issues/4
Relate-to: https://github.com/Z-Wave-Alliance/zwave_xml/issues/103

<!--
SPDX-License-Identifier: BSD-3-Clause
SPDX-FileCopyrightText: 2024 Z-Wave Alliance
-->

<!--
  This is a reminder that all Z-Wave Alliance activities are subject to strict
  compliance with the Z-Wave Antitrust Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/56)
  and IPR Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/43).
  Each individual contributor is responsible to know the contents of these documents
  and to comply with Policies. Copies of all governing documents are available on Causeway.

  Please, DO NOT DELETE ANY TEXT from this template unless instructed!
-->

## Related issue
<!--
  Mention the related issue as described in https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

## Change
<!--
  Describe your changes below.
-->


## Type of change
<!--
  What type of change does your PR introduce?
-->

- [ ] New Feature
- [ ] Bug fix
- [ ] Editorial change
- [x] Refactoring
- [ ] DevOps
- [ ] Breaking
- [ ] Other: (please describe)


## Checklist
<!--
  Please put an `x` in each box to make sure you follow the OSWG Guidelines.
-->

- [x] I have followed the [Contribution Guidelines][contribution-guidelines]
- [x] I agree to the [Developer Certificate of Origin][dco]
- [x] I have cleaned up my commits

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/contribution_guidelines.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
