### PR TITLE
zw_cheadertemplate: Added WOEEN entry to align with 2025B spec.

### DIFF
--- a/XmlFiles/zw_cheadertemplate.h
+++ b/XmlFiles/zw_cheadertemplate.h
@@ -71,6 +71,7 @@
 #define ROLE_TYPE_END_NODE_SLEEPING_REPORTING                                            0x06
 #define ROLE_TYPE_END_NODE_SLEEPING_LISTENING                                            0x07
 #define ROLE_TYPE_END_NODE_NETWORK_AWARE                                                 0x08
+#define ROLE_TYPE_END_NODE_WAKE_ON_EVENT                                                 0x09
 
 
 /************* Z-Wave+ Icon Type identifiers **************/


### PR DESCRIPTION
<!--
SPDX-License-Identifier: BSD-3-Clause
SPDX-FileCopyrightText: 2024 Z-Wave Alliance
-->

<!--
  This is a reminder that all Z-Wave Alliance activities are subject to strict
  compliance with the Z-Wave Antitrust Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/56)
  and IPR Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/43).
  Each individual contributor is responsible to know the contents of these documents
  and to comply with Policies. Copies of all governing documents are available on Causeway.

  Please, DO NOT DELETE ANY TEXT from this template unless instructed!
-->


## Related issue
<!--
  Mention the related issue as described in https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->
https://github.com/Z-Wave-Alliance/z-wave-xml-tools/issues/21

## Change
<!--
  Describe your changes below.
-->
Adding the Missing ROLE_TYPE_END_NODE_WAKE_ON_EVENT entry.

## Type of change
<!--
  What type of change does your PR introduce?
-->

- [ ] New Feature
- [ ] Bug fix
- [x] Editorial change
- [ ] Refactoring
- [ ] DevOps
- [ ] Breaking
- [ ] Other: (please describe)


## Checklist
<!--
  Please put an `x` in each box to make sure you follow the OSWG Guidelines.
-->

- [x] I have followed the [Contribution Guidelines][contribution-guidelines]
- [x] I agree to the [Developer Certificate of Origin][dco]
- [x] I have cleaned up my commits

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/contribution_guidelines.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
