### PR TITLE
Add missing Role Types to Header Generator.

### DIFF
--- a/ZWaveXml/HeaderGenerator/CHGeneratorEx.cs
+++ b/ZWaveXml/HeaderGenerator/CHGeneratorEx.cs
@@ -1,5 +1,6 @@
 /// SPDX-License-Identifier: BSD-3-Clause
 /// SPDX-FileCopyrightText: Silicon Laboratories Inc. https://www.silabs.com
+/// SPDX-FileCopyrightText: Z-Wave Alliance https://z-wavealliance.org
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -101,10 +102,12 @@ namespace ZWave.Xml.HeaderGenerator
                 sw.WriteLine("  ROLE_TYPE_CONTROLLER_SUB_STATIC                                                 = 0x01,");
                 sw.WriteLine("  ROLE_TYPE_CONTROLLER_PORTABLE                                                   = 0x02,");
                 sw.WriteLine("  ROLE_TYPE_CONTROLLER_PORTABLE_REPORTING                                         = 0x03,");
-                sw.WriteLine("  ROLE_TYPE_END_NODE_PORTABLE                                                        = 0x04,");
-                sw.WriteLine("  ROLE_TYPE_END_NODE_ALWAYS_ON                                                       = 0x05,");
-                sw.WriteLine("  ROLE_TYPE_END_NODE_SLEEPING_REPORTING                                              = 0x06,");
-                sw.WriteLine("  ROLE_TYPE_END_NODE_SLEEPING_LISTENING                                              = 0x07,");
+                sw.WriteLine("  ROLE_TYPE_END_NODE_PORTABLE                                                     = 0x04,");
+                sw.WriteLine("  ROLE_TYPE_END_NODE_ALWAYS_ON                                                    = 0x05,");
+                sw.WriteLine("  ROLE_TYPE_END_NODE_SLEEPING_REPORTING                                           = 0x06,");
+                sw.WriteLine("  ROLE_TYPE_END_NODE_SLEEPING_LISTENING                                           = 0x07,");
+                sw.WriteLine("  ROLE_TYPE_END_NODE_NETWORK_AWARE                                                = 0x08,");
+                sw.WriteLine("  ROLE_TYPE_END_NODE_WAKE_ON_EVENT                                                = 0x09,");
                 sw.WriteLine("} ZWAVE_PLUS_ROLE_TYPES;");
                 sw.WriteLine("");
                 sw.WriteLine("/************* Z-Wave+ Icon Type identifiers **************/");


### PR DESCRIPTION
<!--
SPDX-License-Identifier: BSD-3-Clause
SPDX-FileCopyrightText: 2024 Z-Wave Alliance
-->

<!--
  This is a reminder that all Z-Wave Alliance activities are subject to strict
  compliance with the Z-Wave Antitrust Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/56)
  and IPR Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/43).
  Each individual contributor is responsible to know the contents of these documents
  and to comply with Policies. Copies of all governing documents are available on Causeway.

  Please, DO NOT DELETE ANY TEXT from this template unless instructed!
-->

## Related issue
<!--
  Mention the related issue as described in https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

## Change
<!--
  Describe your changes below.
-->

Add missing Role Types to Header Generator.
Adds missing NAEN and new WOEEN.

## Type of change
<!--
  What type of change does your PR introduce?
-->

- [x] New Feature
- [x] Bug fix
- [ ] Editorial change
- [ ] Refactoring
- [ ] DevOps
- [ ] Breaking
- [ ] Other: (please describe)


## Checklist
<!--
  Please put an `x` in each box to make sure you follow the OSWG Guidelines.
-->

- [x] I have followed the [Contribution Guidelines][contribution-guidelines]
- [x] I agree to the [Developer Certificate of Origin][dco]
- [x] I have cleaned up my commits

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/contribution_guidelines.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
