### PR TITLE
Clarify NodeTypes enum. Make sure it is a byte.

### DIFF
--- a/ZWave/Enums/NodeTypes.cs
+++ b/ZWave/Enums/NodeTypes.cs
@@ -1,8 +1,9 @@
 /// SPDX-License-Identifier: BSD-3-Clause
 /// SPDX-FileCopyrightText: Silicon Laboratories Inc. https://www.silabs.com
+/// SPDX-FileCopyrightText: Z-Wave Alliance https://z-wavealliance.org
 namespace ZWave.Enums
 {
-    public enum NodeTypes
+    public enum NodeTypes : byte
     {
         None = 0xFF,
         ZWAVEPLUS_NODE = 0x00,


### PR DESCRIPTION
<!--
SPDX-License-Identifier: BSD-3-Clause
SPDX-FileCopyrightText: 2024 Z-Wave Alliance
-->

<!--
  This is a reminder that all Z-Wave Alliance activities are subject to strict
  compliance with the Z-Wave Antitrust Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/56)
  and IPR Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/43).
  Each individual contributor is responsible to know the contents of these documents
  and to comply with Policies. Copies of all governing documents are available on Causeway.

  Please, DO NOT DELETE ANY TEXT from this template unless instructed!
-->

## Related issue
<!--
  Mention the related issue as described in https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

## Change
<!--
  Describe your changes below.
-->

Clarify NodeTypes enum. Make sure it is a byte.
Fixes the issue where the enum could not be simply parsed back into a byte for the Z-Wave Plus Info Report.

<img width="820" height="274" alt="image" src="https://github.com/user-attachments/assets/cfc95097-79a3-4d61-8c6f-3cd2cf2c9c94" />


<img width="873" height="352" alt="image" src="https://github.com/user-attachments/assets/1209a41f-a3e2-47bd-9b27-439a82347dd5" />


## Type of change
<!--
  What type of change does your PR introduce?
-->

- [ ] New Feature
- [x] Bug fix
- [ ] Editorial change
- [x] Refactoring
- [ ] DevOps
- [ ] Breaking
- [ ] Other: (please describe)


## Checklist
<!--
  Please put an `x` in each box to make sure you follow the OSWG Guidelines.
-->

- [x] I have followed the [Contribution Guidelines][contribution-guidelines]
- [x] I agree to the [Developer Certificate of Origin][dco]
- [x] I have cleaned up my commits

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/contribution_guidelines.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
