### PR TITLE
Add support for new chip types and clean up code

### DIFF
--- a/BasicApplication/Devices/TestInterfaceDevice.cs
+++ b/BasicApplication/Devices/TestInterfaceDevice.cs
@@ -1,11 +1,7 @@
 /// SPDX-License-Identifier: BSD-3-Clause
 /// SPDX-FileCopyrightText: Silicon Laboratories Inc. https://www.silabs.com
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Utils;
 using ZWave.BasicApplication.Operations;
 using ZWave.BasicApplication.Tasks;
@@ -13,7 +9,6 @@ using ZWave.Enums;
 using ZWave.Exceptions;
 using ZWave.Layers;
 using ZWave.Layers.Application;
-using static ZWave.BasicApplication.Devices.TestInterfaceDevice;
 
 namespace ZWave.BasicApplication.Devices
 {
@@ -411,8 +406,10 @@ namespace ZWave.BasicApplication.Devices
                                 break;
                         }
                         break;
+                    case ChipTypes.ZG23_BRD4204A:
                     case ChipTypes.ZG23_BRD4204C:
                     case ChipTypes.ZG23_BRD4204D:
+                    case ChipTypes.ZG23_BRD4210A:
                     case ChipTypes.ZGM230S_BRD4205A:
                     case ChipTypes.ZGM230S_BRD4205B:
                         switch (maskType)

--- a/ZWave/Enums/ChipTypes.cs
+++ b/ZWave/Enums/ChipTypes.cs
@@ -53,6 +53,8 @@ namespace ZWave.Enums
         RZ13_BRD4209A,
 
         [Description("EFR32ZG23 868-915 MHz 14 dBm Radio Board")]
+        ZG23_BRD4204A,
+        [Description("EFR32ZG23 868-915 MHz 14 dBm Radio Board")]
         ZG23_BRD4204C,
         [Description("EFR32ZG23 868-915 MHz 14 dBm Radio Board")]
         ZG23_BRD4204D,


### PR DESCRIPTION
Extended `TestInterfaceDevice` to support `ZG23_BRD4210A` and `ZGM230S_BRD4205B` chip types. Updated `ChipTypes.cs` to include `ZG23_BRD4204A` with its description. Removed unused `using` directives from `TestInterfaceDevice.cs` to improve readability.

<!--
SPDX-License-Identifier: BSD-3-Clause
SPDX-FileCopyrightText: 2024 Z-Wave Alliance
-->

<!--
  This is a reminder that all Z-Wave Alliance activities are subject to strict
  compliance with the Z-Wave Antitrust Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/56)
  and IPR Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/43).
  Each individual contributor is responsible to know the contents of these documents
  and to comply with Policies. Copies of all governing documents are available on Causeway.

  Please, DO NOT DELETE ANY TEXT from this template unless instructed!
-->

## Related issue
<!--
  Mention the related issue as described in https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

## Change
<!--
  Describe your changes below.
-->


## Type of change
<!--
  What type of change does your PR introduce?
-->

- [X] New Feature
- [ ] Bug fix
- [ ] Editorial change
- [ ] Refactoring
- [ ] DevOps
- [ ] Breaking
- [ ] Other: (please describe)


## Checklist
<!--
  Please put an `x` in each box to make sure you follow the OSWG Guidelines.
-->

- [X] I have followed the [Contribution Guidelines][contribution-guidelines]
- [X] I agree to the [Developer Certificate of Origin][dco]
- [X] I have cleaned up my commits

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/contribution_guidelines.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
