### PR TITLE
Remove personal access token (PAT) from GH workflow.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,6 @@
 # SPDX-FileCopyrightText: Z-Wave Alliance https://z-wavealliance.org
 # SPDX-FileCopyrightText: Trident IoT, LLC https://www.tridentiot.com
 
-# This workflow requires a secret named GH_ZWAVE_ACCESS_TOKEN that contains
-# a Personal Access Token with read-only permissions to "Contents".
 name: Build and Test Z-Wave Tools Core
 
 on:
@@ -45,7 +43,6 @@ jobs:
       - name: Checkout z-wave-tools-core
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GH_ZWAVE_ACCESS_TOKEN }}
           path: 'z-wave-tools-core'
           submodules: true # https://github.com/Z-Wave-Alliance/z-wave-tools-core/issues/5
 


### PR DESCRIPTION
<!--
SPDX-License-Identifier: BSD-3-Clause
SPDX-FileCopyrightText: 2024 Z-Wave Alliance
-->

<!--
  This is a reminder that all Z-Wave Alliance activities are subject to strict
  compliance with the Z-Wave Antitrust Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/56)
  and IPR Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/43).
  Each individual contributor is responsible to know the contents of these documents
  and to comply with Policies. Copies of all governing documents are available on Causeway.

  Please, DO NOT DELETE ANY TEXT from this template unless instructed!
-->

## Related issue
<!--
  Mention the related issue as described in https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

compare https://github.com/Z-Wave-Alliance/z-wave-pc-controller/pull/41 and https://github.com/Z-Wave-Alliance/z-wave-automated-test-system/pull/62

## Change
<!--
  Describe your changes below.
-->

Remove personal access token (PAT) from GH workflow.
PAT not needed anymore since the submodule z-wave-blobs is now public.

## Type of change
<!--
  What type of change does your PR introduce?
-->

- [x] New Feature
- [ ] Bug fix
- [ ] Editorial change
- [x] Refactoring
- [ ] DevOps
- [ ] Breaking
- [ ] Other: (please describe)


## Checklist
<!--
  Please put an `x` in each box to make sure you follow the OSWG Guidelines.
-->

- [x] I have followed the [Contribution Guidelines][contribution-guidelines]
- [x] I agree to the [Developer Certificate of Origin][dco]
- [x] I have cleaned up my commits

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/contribution_guidelines.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
