### PR TITLE
Upgrade .NET to version 10.0.

### DIFF
--- a/BasicApplication/BasicApplication_netcore.csproj
+++ b/BasicApplication/BasicApplication_netcore.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>ZWaveBasicApplication</AssemblyName>
-    <TargetFrameworks>net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net10.0;net48</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>

--- a/ProgrammerApplication/ProgrammerApplication_netcore.csproj
+++ b/ProgrammerApplication/ProgrammerApplication_netcore.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>ProgrammerApplication</AssemblyName>
-    <TargetFrameworks>net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net10.0;net48</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>

--- a/UicApplication/UicApplication.csproj
+++ b/UicApplication/UicApplication.csproj
@@ -136,7 +136,7 @@
       <Version>3.1.2</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.3</Version>
+      <Version>13.0.4</Version>
     </PackageReference>
     <PackageReference Include="Renci.SshNet.Async">
       <Version>1.4.0</Version>

--- a/UicApplication/UicApplication_netcore.csproj
+++ b/UicApplication/UicApplication_netcore.csproj
@@ -2,12 +2,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>UicApplication</AssemblyName>
-    <TargetFrameworks>net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net10.0;net48</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MQTTnet.Extensions.Rpc" Version="3.1.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Renci.SshNet.Async" Version="1.4.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Utils/Extensions/RandomNumberGeneratorExt.cs
+++ b/Utils/Extensions/RandomNumberGeneratorExt.cs
@@ -1,15 +1,16 @@
 /// SPDX-License-Identifier: BSD-3-Clause
 /// SPDX-FileCopyrightText: Silicon Laboratories Inc. https://www.silabs.com
+/// SPDX-FileCopyrightText: Z-Wave Alliance https://z-wavealliance.org
 using System.Security.Cryptography;
 
 namespace Utils.Extensions
 {
-    public static class RNGCryptoServiceProviderExt
+    public static class RandomNumberGeneratorExt
     {
-        public static byte NextByte(this RNGCryptoServiceProvider rnd)
+        public static byte NextByte(this RandomNumberGenerator rng)
         {
             var arr = new byte[1];
-            rnd.GetBytes(arr);
+            rng.GetBytes(arr);
             return arr[0];
         }
     }

--- a/Utils/Utils.csproj
+++ b/Utils/Utils.csproj
@@ -52,6 +52,7 @@
     <Compile Include="EnumDescriptionTypeConverter.cs" />
     <Compile Include="EnumExtensions.cs" />
     <Compile Include="Events\EventArgs.cs" />
+    <Compile Include="Extensions\RandomNumberGeneratorExt.cs" />
     <Compile Include="Extensions\TaskExtensions.cs" />
     <Compile Include="FileAccessMonitor.cs" />
     <Compile Include="IgnoreCaseEqualityComparer.cs" />
@@ -93,7 +94,6 @@
     <Compile Include="Extensions\EnumerableExt.cs" />
     <Compile Include="Extensions\ValueExt.cs" />
     <Compile Include="Extensions\RefTypeExt.cs" />
-    <Compile Include="Extensions\RNGCryptoServiceProviderExt.cs" />
     <Compile Include="Extensions\ShouldBeNotNullExtension.cs" />
     <Compile Include="Extentions.cs" />
     <Compile Include="IntRef.cs" />

--- a/Utils/Utils_netcore.csproj
+++ b/Utils/Utils_netcore.csproj
@@ -2,15 +2,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Utils</AssemblyName>
-    <TargetFrameworks>net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net10.0;net48</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
+    <!-- for .NET (Core) -->
     <Compile Remove="WinBased\**" />
     <PackageReference Include="System.IO.Ports" Version="8.0.0" />
-    <PackageReference Include="System.IO.Packaging" Version="8.0.0" />
+    <PackageReference Include="System.IO.Packaging" Version="10.0.2" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+    <!-- for .NET Framework 4.8 -->
     <Reference Include="System.Management" />
     <Reference Include="WindowsBase" />
   </ItemGroup>

--- a/ZWave/Security/S2/SecurityS2CryptoProviderBase.cs
+++ b/ZWave/Security/S2/SecurityS2CryptoProviderBase.cs
@@ -1,5 +1,6 @@
 /// SPDX-License-Identifier: BSD-3-Clause
 /// SPDX-FileCopyrightText: Silicon Laboratories Inc. https://www.silabs.com
+/// SPDX-FileCopyrightText: Z-Wave Alliance https://z-wavealliance.org
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,7 +14,7 @@ namespace ZWave.Security
 {
     public class SecurityS2CryptoProviderBase
     {
-        protected RNGCryptoServiceProvider _rngCryptoServiceProvider = new RNGCryptoServiceProvider();
+        protected RandomNumberGenerator _randomNumberGenerator = RandomNumberGenerator.Create();
 
         public static int MaxMpanIterations = 5;
         public byte LastSentMulticastGroupId { get; protected set; }
@@ -21,7 +22,7 @@ namespace ZWave.Security
         protected byte[] GetEntropyInput()
         {
             byte[] entropy_input = new byte[SecurityS2Utils.PERSONALIZATION_SIZE];
-            _rngCryptoServiceProvider.GetBytes(entropy_input);
+            _randomNumberGenerator.GetBytes(entropy_input);
             return entropy_input;
         }
 

--- a/ZWave/ZWave_netcore.csproj
+++ b/ZWave/ZWave_netcore.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<AssemblyName>ZWave</AssemblyName>
-		<TargetFrameworks>net6.0;net48</TargetFrameworks>
+		<TargetFrameworks>net10.0;net48</TargetFrameworks>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 	</PropertyGroup>
 	<ItemGroup Condition="'$(RuntimeIdentifier)' == ''">

--- a/ZWaveXml/ZWaveXml_netcore.csproj
+++ b/ZWaveXml/ZWaveXml_netcore.csproj
@@ -2,13 +2,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>ZWaveXml</AssemblyName>
-    <TargetFrameworks>net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net10.0;net48</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Utils\Utils_netcore.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
+    <!-- for .NET (Core), not .NET Framework -->
     <PackageReference Include="System.Security.Permissions" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/ZipApplication/ZipApplication_netcore.csproj
+++ b/ZipApplication/ZipApplication_netcore.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<AssemblyName>ZWaveZipApplication</AssemblyName>
-		<TargetFrameworks>net6.0;net48</TargetFrameworks>
+		<TargetFrameworks>net10.0;net48</TargetFrameworks>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 	</PropertyGroup>
 	<ItemGroup Condition="'$(RuntimeIdentifier)' == 'win-x64'">
@@ -24,7 +24,7 @@
 		<Content Include="..\z-wave-blobs\z-wave-tools-core\ZipTransport\arm\libziptrans32.so" CopyToOutputDirectory="PreserveNewest" />
 	</ItemGroup>
 	<ItemGroup>
-	  <PackageReference Include="SSH.NET" Version="2020.0.2" />
+	  <PackageReference Include="SSH.NET" Version="2025.1.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Utils\Utils_netcore.csproj" />

--- a/ZnifferApplication/DataItem.cs
+++ b/ZnifferApplication/DataItem.cs
@@ -1,5 +1,7 @@
 /// SPDX-License-Identifier: BSD-3-Clause
 /// SPDX-FileCopyrightText: Silicon Laboratories Inc. https://www.silabs.com
+/// SPDX-FileCopyrightText: Z-Wave Alliance https://z-wavealliance.org
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -780,14 +782,14 @@ namespace ZWave.ZnifferApplication
 
         public static DataItem DeepClone(DataItem obj)
         {
-            using (var ms = new MemoryStream())
+            if (obj == null)
             {
-                var formatter = new BinaryFormatter();
-                formatter.Serialize(ms, obj);
-                ms.Position = 0;
-
-                return (DataItem)formatter.Deserialize(ms);
+                return null;
             }
+            // Initialize inner objects individually.
+            // Without 'ObjectCreationHandling.Replace' default constructor values would be added to result.
+            var deserializeSettings = new JsonSerializerSettings { ObjectCreationHandling = ObjectCreationHandling.Replace };
+            return JsonConvert.DeserializeObject<ZWave.ZnifferApplication.DataItem>(JsonConvert.SerializeObject(obj), deserializeSettings);
         }
 
         public CipherDataItem Decrypt(SecurityManager securityManager)

--- a/ZnifferApplication/ZnifferApplication.csproj
+++ b/ZnifferApplication/ZnifferApplication.csproj
@@ -31,6 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.13.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
@@ -97,6 +100,9 @@
       <Project>{B214D482-57EB-42BE-AEC7-D64850F56514}</Project>
       <Name>ZWave</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/ZnifferApplication/ZnifferApplication_netcore.csproj
+++ b/ZnifferApplication/ZnifferApplication_netcore.csproj
@@ -2,9 +2,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>ZWaveZnifferApplication</AssemblyName>
-    <TargetFrameworks>net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net10.0;net48</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+  </ItemGroup>
   <ItemGroup>
   	<ProjectReference Include="..\Utils\Utils_netcore.csproj" />
     <ProjectReference Include="..\ZWave\ZWave_netcore.csproj" />

--- a/ZnifferApplication/packages.config
+++ b/ZnifferApplication/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net48" />
   <package id="NUnit" version="3.12.0" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
<!--
SPDX-License-Identifier: BSD-3-Clause
SPDX-FileCopyrightText: 2024 Z-Wave Alliance
-->

<!--
  This is a reminder that all Z-Wave Alliance activities are subject to strict
  compliance with the Z-Wave Antitrust Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/56)
  and IPR Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/43).
  Each individual contributor is responsible to know the contents of these documents
  and to comply with Policies. Copies of all governing documents are available on Causeway.

  Please, DO NOT DELETE ANY TEXT from this template unless instructed!
-->

## Related issue
<!--
  Mention the related issue as described in https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

.NET 6.0 is out of support.

## Change
<!--
  Describe your changes below.
-->

- Upgrade .NET to version 10.0.
- Update packages:
  - Newtonsoft.Json, version 13.0.4
  - SSH.NET, version 2025.1.0
  - System.IO.Packaging, version 10.0.2
- Replace obsoleted BinaryFormatter with JSON Serializer/Deserializer for creating a deep copy.
- Replace obsoleted RNGCryptoServiceProvider with RandomNumberGenerator.

## Type of change
<!--
  What type of change does your PR introduce?
-->

- [x] New Feature
- [x] Bug fix
- [ ] Editorial change
- [x] Refactoring
- [ ] DevOps
- [ ] Breaking
- [ ] Other: (please describe)


## Checklist
<!--
  Please put an `x` in each box to make sure you follow the OSWG Guidelines.
-->

- [x] I have followed the [Contribution Guidelines][contribution-guidelines]
- [x] I agree to the [Developer Certificate of Origin][dco]
- [x] I have cleaned up my commits

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/contribution_guidelines.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
