### PR TITLE
feat: Update Z-Wave Command Classes in accordance with Z-Wave XML 2.19.1.

### DIFF
--- a/XmlFiles/zwave.xml
+++ b/XmlFiles/zwave.xml
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="US-ASCII"?>
+<?xml version="1.0" encoding="us-ascii"?>
 <!--
 SPDX-License-Identifier: BSD-3-Clause
 SPDX-FileCopyrightText: Z-Wave-Alliance https://z-wavealliance.org
 -->
-<zw_classes version="2.19.0">
+<zw_classes version="2.19.1">
   <bas_dev key="0x01" name="BASIC_TYPE_CONTROLLER" help="Controller" comment="Node is a portable controller" />
   <bas_dev key="0x04" name="BASIC_TYPE_ROUTING_END_NODE" help="Routing End Node" comment="Node is an End Node with routing capabilities" />
   <bas_dev key="0x03" name="BASIC_TYPE_END_NODE" help="End Node" comment="Node is an End Node" />
@@ -3676,9 +3676,13 @@ SPDX-FileCopyrightText: Z-Wave-Alliance https://z-wavealliance.org
         <const key="0x06" flagname="Invalid file header format" flagmask="0x06" />
         <const key="0x07" flagname="Insufficient memory" flagmask="0x07" />
         <const key="0x08" flagname="does not match the Hardware version" flagmask="0x08" />
-        <const key="0x09" flagname="successfully, waiting for activation" flagmask="0xFD" />
-        <const key="0x0A" flagname="successfully stored" flagmask="0xFE" />
-        <const key="0x0B" flagname="successfully" flagmask="0xFF" />
+        <const key="0x09" flagname="Invalid signature" flagmask="0x09" />
+        <const key="0x0A" flagname="Decryption failed" flagmask="0x0A" />
+        <const key="0x0B" flagname="Decompression failed" flagmask="0x0B" />
+        <const key="0x0C" flagname="Downgrade unsupported" flagmask="0x0C" />
+        <const key="0x0D" flagname="successfully, waiting for activation" flagmask="0xFD" />
+        <const key="0x0E" flagname="successfully stored" flagmask="0xFE" />
+        <const key="0x0F" flagname="successfully" flagmask="0xFF" />
       </param>
       <param key="0x01" name="WaitTime" type="WORD" />
     </cmd>
@@ -13935,7 +13939,7 @@ SPDX-FileCopyrightText: Z-Wave-Alliance https://z-wavealliance.org
       </param>
     </cmd>
   </cmd_class>
-  <cmd_class key="0x01" version="1" name="ZWAVE_CMD_CLASS" help="Z-Wave protocol Command Class">
+  <cmd_class key="0x01" version="1" name="ZWAVE_CMD_CLASS" help="Command Class Z-Wave Protocol">
     <cmd key="0x17" name="ACCEPT_LOST" help="Accept Lost" comment="SDS10264-2">
       <param key="0x00" name="Accept Status" type="BYTE">
         <bitflag key="0x01" flagname="Request failed" flagmask="0x04" />
@@ -14176,7 +14180,6 @@ SPDX-FileCopyrightText: Z-Wave-Alliance https://z-wavealliance.org
         <const key="0x02" flagname="250ms wakeup beam" flagmask="0x02" />
       </param>
     </cmd>
-    <cmd key="0x00" name="ZWAVE_CMD_NOP" help="NOP" />
     <cmd key="0x18" name="CMD_NOP_POWER" help="NOP Power">
       <param key="0x00" name="Tx Power Register (Obsolete)" type="CONST">
         <const key="0x00" flagname="Not used" flagmask="0x00" />
@@ -17045,8 +17048,9 @@ SPDX-FileCopyrightText: Z-Wave-Alliance https://z-wavealliance.org
       <param key="0x00" name="Properties1" type="STRUCT_BYTE">
         <bitflag key="0x00" flagname="Echo" flagmask="0x01" />
         <bitflag key="0x01" flagname="Request CSA" flagmask="0x02" />
-        <bitflag key="0x02" flagname="NLS Support" flagmask="0x04" />
-        <bitfield key="0x03" fieldname="Reserved" fieldmask="0xF8" shifter="3" />
+        <bitflag key="0x02" flagname="NLS Alpha" flagmask="0x04" />
+        <bitflag key="0x03" flagname="NLS Support" flagmask="0x08" />
+        <bitfield key="0x04" fieldname="Reserved" fieldmask="0xF0" shifter="4" />
       </param>
       <param key="0x01" name="Supported KEX Schemes" type="BYTE" />
       <param key="0x02" name="Supported ECDH Profiles" type="BYTE" />

--- a/ZWave/CommandClasses/COMMAND_CLASS_SECURITY_2_V2.cs
+++ b/ZWave/CommandClasses/COMMAND_CLASS_SECURITY_2_V2.cs
@@ -285,15 +285,20 @@ namespace ZWave.CommandClasses
                     get { return (byte)(_value >> 1 & 0x01); }
                     set { HasValue = true; _value &= 0xFF - 0x02; _value += (byte)(value << 1 & 0x02); }
                 }
-                public byte nlsSupport
+                public byte nlsAlpha
                 {
                     get { return (byte)(_value >> 2 & 0x01); }
                     set { HasValue = true; _value &= 0xFF - 0x04; _value += (byte)(value << 2 & 0x04); }
                 }
+                public byte nlsSupport
+                {
+                    get { return (byte)(_value >> 3 & 0x01); }
+                    set { HasValue = true; _value &= 0xFF - 0x08; _value += (byte)(value << 3 & 0x08); }
+                }
                 public byte reserved
                 {
-                    get { return (byte)(_value >> 3 & 0x1F); }
-                    set { HasValue = true; _value &= 0xFF - 0xF8; _value += (byte)(value << 3 & 0xF8); }
+                    get { return (byte)(_value >> 4 & 0x0F); }
+                    set { HasValue = true; _value &= 0xFF - 0xF0; _value += (byte)(value << 4 & 0xF0); }
                 }
                 public static implicit operator Tproperties1(byte data)
                 {

--- a/ZWave/CommandClasses/ZWAVE_CMD_CLASS.cs
+++ b/ZWave/CommandClasses/ZWAVE_CMD_CLASS.cs
@@ -1090,22 +1090,6 @@ namespace ZWave.CommandClasses
                 return ret.ToArray();
             }
         }
-        public partial class ZWAVE_CMD_NOP
-        {
-            public const byte ID = 0x00;
-            public static implicit operator ZWAVE_CMD_NOP(byte[] data)
-            {
-                ZWAVE_CMD_NOP ret = new ZWAVE_CMD_NOP();
-                return ret;
-            }
-            public static implicit operator byte[](ZWAVE_CMD_NOP command)
-            {
-                List<byte> ret = new List<byte>();
-                ret.Add(ZWAVE_CMD_CLASS.ID);
-                ret.Add(ID);
-                return ret.ToArray();
-            }
-        }
         public partial class CMD_NOP_POWER
         {
             public const byte ID = 0x18;


### PR DESCRIPTION
<!--
SPDX-License-Identifier: BSD-3-Clause
SPDX-FileCopyrightText: 2024 Z-Wave Alliance
-->

<!--
  This is a reminder that all Z-Wave Alliance activities are subject to strict
  compliance with the Z-Wave Antitrust Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/56)
  and IPR Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/43).
  Each individual contributor is responsible to know the contents of these documents
  and to comply with Policies. Copies of all governing documents are available on Causeway.

  Please, DO NOT DELETE ANY TEXT from this template unless instructed!
-->

## Related issue
<!--
  Mention the related issue as described in https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

e.g. https://github.com/Z-Wave-Alliance/z-wave-xml/issues/187

## Change
<!--
  Describe your changes below.
-->
feat: Update Z-Wave Command Classes in accordance with Z-Wave XML 2.19.1.

Breaking change: S2v2, KEX Report, "NLS Support" flag was moved to bit 3.
Compare: https://github.com/Z-Wave-Alliance/z-wave-xml/pull/188
S2v2 had never been certified before.

## Type of change
<!--
  What type of change does your PR introduce?
-->

- [x] New Feature
- [ ] Bug fix
- [ ] Editorial change
- [ ] Refactoring
- [ ] DevOps
- [x] Breaking – S2v2 was never certified so far.
- [ ] Other: (please describe)


## Checklist
<!--
  Please put an `x` in each box to make sure you follow the OSWG Guidelines.
-->

- [x] I have followed the [Contribution Guidelines][contribution-guidelines]
- [x] I agree to the [Developer Certificate of Origin][dco]
- [x] I have cleaned up my commits

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/contribution_guidelines.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
