### PR TITLE
feat: Implement length validation for commands.

### DIFF
--- a/ZWaveXml/Application/ZWaveDefinitionExt.cs
+++ b/ZWaveXml/Application/ZWaveDefinitionExt.cs
@@ -686,6 +686,10 @@ namespace ZWave.Xml.Application
             secureCommandClasses = secureCmdClasses.Count > 0 ? secureCmdClasses.ToArray() : null;
         }
 
+        /// <summary>
+        /// Validate a command's payload length is matching a specific command class version according to the Z-Wave definition.
+        /// This can, for example, be used to verify a command is matching the supported version advertised by a device.
+        /// </summary>
         public PayloadParseResult ValidatePayloadLength(byte[] payload, byte expectedCCVersion)
         {
             if (payload == null || payload.Length < 2)
@@ -722,7 +726,7 @@ namespace ZWave.Xml.Application
 
             return new PayloadParseResult
             {
-                Type = ParseResultType.Succsess,
+                Type = ParseResultType.Success,
                 CommandClassId = cc,
                 CommandId = cmd,
                 CommandClassVersion = expectedCCVersion,
@@ -780,7 +784,7 @@ namespace ZWave.Xml.Application
                     return false;
                 }
 
-                resultType = ParseResultType.Succsess;
+                resultType = ParseResultType.Success;
                 return true;
             }
             catch (Exception ex)
@@ -856,8 +860,7 @@ namespace ZWave.Xml.Application
         {
             LengthMismatch,
             ParseFailed,
-            VersionMismatch,
-            Succsess
+            Success
         }
     }
 }

--- a/ZWaveXml/Application/ZWaveDefinitionExt.cs
+++ b/ZWaveXml/Application/ZWaveDefinitionExt.cs
@@ -1,5 +1,6 @@
 /// SPDX-License-Identifier: BSD-3-Clause
-/// SPDX-FileCopyrightText: Silicon Laboratories Inc. https://www.silabs.com
+/// SPDX-FileCopyrightText: Silicon Laboratories Inc. <https://www.silabs.com>
+/// SPDX-FileCopyrightText: Z-Wave-Alliance <https://z-wavealliance.org>
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -683,6 +684,186 @@ namespace ZWave.Xml.Application
             }
             commandClasses = cmdClasses.Count > 0 ? cmdClasses.ToArray() : null;
             secureCommandClasses = secureCmdClasses.Count > 0 ? secureCmdClasses.ToArray() : null;
+        }
+
+        public PayloadParseIssue ValidatePayloadLength(byte[] payload, byte expectedCCVersion, string sourceInfo = null)
+        {
+            if (payload == null || payload.Length < 2)
+                return null;
+
+            byte cc = payload[0];
+            byte cmd = payload[1];
+
+            if (!TryNormalizeWithZWaveDefinition(payload, expectedCCVersion, out byte[] normalized, out string details))
+            {
+                var issue = new PayloadParseIssue
+                {
+                    Type = ScriptParseIssueType.ParseFailed,
+                    CommandClassId = cc,
+                    CommandId = cmd,
+                    PayloadLength = payload.Length,
+                    NormalizedLength = null,
+                    Payload = payload.ToArray(),
+                    Details = new List<string>() { details ??  "No parse candidate matched or normalization failed." },
+                    SourceInfo = sourceInfo
+                };
+
+                return issue;
+            }
+
+            if (normalized != null && normalized.Length != payload.Length)
+            {
+                var issue = new PayloadParseIssue
+                {
+                    Type = ScriptParseIssueType.TrailingBytes,
+                    CommandClassId = cc,
+                    CommandId = cmd,
+                    PayloadLength = payload.Length,
+                    NormalizedLength = normalized.Length,
+                    Payload = payload.ToArray(),
+                    Details = new List<string>() { "Received payload did not match the", "supported command class version." },
+                    SourceInfo = sourceInfo
+                };
+
+                return issue;
+            }
+
+            return null;
+        }
+
+        private bool TryNormalizeWithZWaveDefinition(byte[] payload, byte expectedCCVersion, out byte[] normalized, out string details)
+        {
+            normalized = null;
+            details = null;
+
+            try
+            {
+                CommandClassValue[] values = null;
+                ParseApplicationObject(payload, out values);
+
+                if (values == null || values.Length == 0)
+                {
+                    details = "ParseApplicationObject returned no values.";
+                    return false;
+                }
+
+                byte cc = payload[0];
+                byte cmd = payload[1];
+                var candidates = values
+                    .Where(v =>
+                        v?.CommandClassDefinition != null &&
+                        v.CommandValue?.CommandDefinition != null &&
+                        v.CommandClassDefinition.KeyId == cc &&
+                        v.CommandValue.CommandDefinition.KeyId == cmd)
+                    .ToList();
+
+                if (candidates.Count == 0)
+                {
+                    details = $"No parsed candidate matched CC=0x{cc:X2}, CMD=0x{cmd:X2}.";
+                    return false;
+                }
+
+                // strict on known version
+                if (candidates.FirstOrDefault(v => v.CommandClassDefinition.Version == expectedCCVersion) is CommandClassValue candidate)
+                {
+                    var paramValues = candidate.CommandValue.ParamValues?.ToList() ?? new List<ParamValue>();
+                    normalized = FillCommand(
+                        candidate.CommandClassDefinition,
+                        candidate.CommandValue.CommandDefinition,
+                        paramValues);
+
+                    if (normalized == null || normalized.Length < 2)
+                    {
+                        details = "FillCommand produced no valid payload.";
+                        return false;
+                    }
+                }
+                else
+                {
+                    var seenVersions = string.Join(",", candidates.Select(v => v.CommandClassDefinition.Version).Distinct().OrderBy(v => v));
+                    details = $"No candidate matched expected CC version {expectedCCVersion}. Seen versions: [{seenVersions}] for CC=0x{cc:X2}, CMD=0x{cmd:X2}.";
+                    return false;
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                details = $"Normalization failed: {ex.Message}";
+                return false;
+            }
+        }
+
+        private static void FillCommandInner(List<ParamValue> parameters, ref List<byte> data)
+        {
+            if (parameters != null && parameters.Count > 0)
+            {
+                byte structByte = 0;
+                byte structByteBitCounter = 0;
+                foreach (ParamValue var in parameters)
+                {
+
+                    if (var.ParamDefinition.Bits > 0 && var.ParamDefinition.Bits < 8 && var.ByteValueList.Count > 0)
+                    {
+                        byte tt = (byte)(var.ByteValueList[0] << structByteBitCounter);
+                        structByteBitCounter += var.ParamDefinition.Bits;
+                        structByte += tt;
+                    }
+                    else
+                    {
+                        data.AddRange(var.ByteValueList);
+                    }
+
+                    if (structByteBitCounter == 8)
+                    {
+                        data.Add(structByte);
+                        structByte = 0;
+                        structByteBitCounter = 0;
+                    }
+                    else if (structByteBitCounter > 8)
+                    {
+                        throw new ApplicationException("Invalid payload");
+                    }
+                }
+            }
+        }
+
+        public static byte[] FillCommand(CommandClass cmdClass, Command cmd, List<ParamValue> parameters)
+        {
+            List<byte> data = new List<byte>();
+            FillCommandInner(parameters, ref data);
+            return FillCommand(cmdClass.KeyId, cmd.KeyId, data.ToArray());
+        }
+
+        public static byte[] FillCommand(byte cmdClass, byte command, byte[] data)
+        {
+            List<byte> ret = new List<byte>();
+            ret.Add(cmdClass);
+            ret.Add(command);
+            if (data != null && data.Length > 0)
+            {
+                ret.AddRange(data);
+            }
+            return ret.ToArray();
+        }
+
+        public sealed class PayloadParseIssue
+        {
+            public ScriptParseIssueType Type { get; set; }
+            public byte CommandClassId { get; set; }
+            public byte CommandId { get; set; }
+            public int PayloadLength { get; set; }
+            public int? NormalizedLength { get; set; }
+            public List<string> Details { get; set; }
+            public byte[] Payload { get; set; }
+            public DateTime TimestampUtc { get; set; } = DateTime.UtcNow;
+            public string SourceInfo { get; set; } // optional context (node/frame)
+        }
+
+        public enum ScriptParseIssueType
+        {
+            TrailingBytes,
+            ParseFailed
         }
     }
 }

--- a/ZWaveXml/Application/ZWaveDefinitionExt.cs
+++ b/ZWaveXml/Application/ZWaveDefinitionExt.cs
@@ -699,45 +699,33 @@ namespace ZWave.Xml.Application
 
             byte cc = payload[0];
             byte cmd = payload[1];
-            var normalizeResult = NormalizeWithZWaveDefinition(payload, expectedCCVersion);
 
-            if (normalizeResult.Type != ParseResultType.Success)
+            var result = new PayloadParseResult
             {
-                return new PayloadParseResult
-                {
-                    Type = normalizeResult.Type,
-                    CommandClassId = cc,
-                    CommandId = cmd,
-                    CommandClassVersion = expectedCCVersion,
-                    OriginalPayload = payload,
-                    NormalizedPayload = null
-                };
-            }
-
-            byte[] normalizedPayload = normalizeResult.NormalizedPayload;
-
-            if (normalizedPayload != null && normalizedPayload.Length != payload.Length)
-            {
-                return new PayloadParseResult
-                {
-                    Type = ParseResultType.LengthMismatch,
-                    CommandClassId = cc,
-                    CommandId = cmd,
-                    CommandClassVersion = expectedCCVersion,
-                    OriginalPayload = payload,
-                    NormalizedPayload = normalizedPayload
-                };
-            }
-
-            return new PayloadParseResult
-            {
-                Type = ParseResultType.Success,
+                Type = ParseResultType.ParseFailed, // default/fallback
                 CommandClassId = cc,
                 CommandId = cmd,
                 CommandClassVersion = expectedCCVersion,
                 OriginalPayload = payload,
-                NormalizedPayload = normalizedPayload
+                NormalizedPayload = null
             };
+
+            var normalizeResult = NormalizeWithZWaveDefinition(payload, expectedCCVersion);
+
+            if (normalizeResult.Type == ParseResultType.Success)
+            {
+                var normalizedPayload = normalizeResult.NormalizedPayload;
+                result.NormalizedPayload = normalizedPayload;
+                result.Type = (normalizedPayload != null && normalizedPayload.Length != payload.Length)
+                    ? ParseResultType.LengthMismatch
+                    : ParseResultType.Success;
+            }
+            else
+            {
+                result.Type = normalizeResult.Type;
+            }
+
+            return result;
         }
 
         private NormalizeResult NormalizeWithZWaveDefinition(byte[] payload, byte expectedCCVersion)

--- a/ZWaveXml/Application/ZWaveDefinitionExt.cs
+++ b/ZWaveXml/Application/ZWaveDefinitionExt.cs
@@ -692,17 +692,17 @@ namespace ZWave.Xml.Application
         /// </summary>
         public PayloadParseResult ValidatePayloadLength(byte[] payload, byte expectedCCVersion)
         {
-            if (payload == null || payload.Length < 2)
+            if (payload == null || payload.Length < 1)
             {
                 return null;
             }
 
             byte cc = payload[0];
-            byte cmd = payload[1];
+            byte? cmd = payload.Length > 1 ? payload[1] : (byte?)null;
 
             var result = new PayloadParseResult
             {
-                Type = ParseResultType.ParseFailed, // default/fallback
+                Type = PayloadParseResultType.ParseFailed, // default/fallback
                 CommandClassId = cc,
                 CommandId = cmd,
                 CommandClassVersion = expectedCCVersion,
@@ -710,22 +710,22 @@ namespace ZWave.Xml.Application
                 NormalizedPayload = null
             };
 
-            var normalizeResult = NormalizeWithZWaveDefinition(payload, expectedCCVersion);
+            NormalizeResult normalizeResult = NormalizeWithZWaveDefinition(payload, expectedCCVersion);
 
             if (normalizeResult.Success)
             {
-                var normalizedPayload = normalizeResult.NormalizedPayload;
+                byte[] normalizedPayload = normalizeResult.NormalizedPayload;
                 result.NormalizedPayload = normalizedPayload;
 
                 if(normalizedPayload == null)
                 {
-                    result.Type = ParseResultType.ParseFailed;
+                    result.Type = PayloadParseResultType.ParseFailed;
                 }
                 else
                 {
                     result.Type = (normalizedPayload.Length != payload.Length)
-                        ? ParseResultType.LengthMismatch
-                        : ParseResultType.Success;
+                        ? PayloadParseResultType.LengthMismatch
+                        : PayloadParseResultType.Success;
                 }
             }
 
@@ -797,6 +797,11 @@ namespace ZWave.Xml.Application
         {
             public bool Success { get; set; }
             public byte[] NormalizedPayload { get; set; }
+
+            public static implicit operator bool(NormalizeResult val)
+            {
+                return val.Success;
+            }
         }
 
         private static void FillCommandInner(List<ParamValue> parameters, ref List<byte> data)
@@ -854,15 +859,19 @@ namespace ZWave.Xml.Application
 
         public sealed class PayloadParseResult
         {
-            public ParseResultType Type { get; set; }
-            public byte CommandClassVersion { get; set; }
+            public PayloadParseResultType Type { get; set; }
             public byte CommandClassId { get; set; }
-            public byte CommandId { get; set; }
+            public byte CommandClassVersion { get; set; }
+            /// <summary>
+            /// Command ID is optional because, for example, the classic NOP payload is one byte only
+            /// (i.e., CC ID 0x00) with no Command ID. In this case this field is null.
+            /// </summary>
+            public byte? CommandId { get; set; }
             public byte[] OriginalPayload { get; set; }
             public byte[] NormalizedPayload { get; set; }
         }
 
-        public enum ParseResultType
+        public enum PayloadParseResultType
         {
             Success,
             LengthMismatch,

--- a/ZWaveXml/Application/ZWaveDefinitionExt.cs
+++ b/ZWaveXml/Application/ZWaveDefinitionExt.cs
@@ -704,6 +704,7 @@ namespace ZWave.Xml.Application
             {
                 Type = PayloadParseResultType.ParseFailed, // default/fallback
                 CommandClassId = cc,
+                CommandClassVersion = expectedCCVersion,
                 CommandId = cmd,
                 OriginalPayload = payload,
                 NormalizedPayload = null

--- a/ZWaveXml/Application/ZWaveDefinitionExt.cs
+++ b/ZWaveXml/Application/ZWaveDefinitionExt.cs
@@ -693,16 +693,19 @@ namespace ZWave.Xml.Application
         public PayloadParseResult ValidatePayloadLength(byte[] payload, byte expectedCCVersion)
         {
             if (payload == null || payload.Length < 2)
+            {
                 return null;
+            }
 
             byte cc = payload[0];
             byte cmd = payload[1];
+            var normalizeResult = NormalizeWithZWaveDefinition(payload, expectedCCVersion);
 
-            if (!TryNormalizeWithZWaveDefinition(payload, expectedCCVersion, out byte[] normalizedPayload, out ParseResultType resultType))
+            if (normalizeResult.Type != ParseResultType.Success)
             {
                 return new PayloadParseResult
                 {
-                    Type = resultType,
+                    Type = normalizeResult.Type,
                     CommandClassId = cc,
                     CommandId = cmd,
                     CommandClassVersion = expectedCCVersion,
@@ -710,6 +713,8 @@ namespace ZWave.Xml.Application
                     NormalizedPayload = null
                 };
             }
+
+            byte[] normalizedPayload = normalizeResult.NormalizedPayload;
 
             if (normalizedPayload != null && normalizedPayload.Length != payload.Length)
             {
@@ -735,10 +740,13 @@ namespace ZWave.Xml.Application
             };
         }
 
-        private bool TryNormalizeWithZWaveDefinition(byte[] payload, byte expectedCCVersion, out byte[] normalized, out ParseResultType resultType)
+        private NormalizeResult NormalizeWithZWaveDefinition(byte[] payload, byte expectedCCVersion)
         {
-            normalized = null;
-            resultType = ParseResultType.ParseFailed;
+            var result = new NormalizeResult
+            {
+                Type = ParseResultType.ParseFailed,
+                NormalizedPayload = null
+            };
 
             try
             {
@@ -747,7 +755,7 @@ namespace ZWave.Xml.Application
 
                 if (values == null || values.Length == 0)
                 {
-                    return false;
+                    return result;
                 }
 
                 byte cc = payload[0];
@@ -762,35 +770,41 @@ namespace ZWave.Xml.Application
 
                 if (candidates.Count == 0)
                 {
-                    return false;
+                    return result;
                 }
-
+                
                 // strict on known version
                 if (candidates.FirstOrDefault(v => v.CommandClassDefinition.Version == expectedCCVersion) is CommandClassValue candidate)
                 {
                     var paramValues = candidate.CommandValue.ParamValues?.ToList() ?? new List<ParamValue>();
-                    normalized = FillCommand(
+                    var normalized = FillCommand(
                         candidate.CommandClassDefinition,
                         candidate.CommandValue.CommandDefinition,
                         paramValues);
 
                     if (normalized == null || normalized.Length < 2)
                     {
-                        return false;
+                        return result;
                     }
-                }
-                else
-                {
-                    return false;
+
+                    result.Type = ParseResultType.Success;
+                    result.NormalizedPayload = normalized;
+
+                    return result;
                 }
 
-                resultType = ParseResultType.Success;
-                return true;
+                return result;
             }
-            catch (Exception ex)
+            catch
             {
-                return false;
+                return result;
             }
+        }
+
+        private sealed class NormalizeResult
+        {
+            public ParseResultType Type { get; set; }
+            public byte[] NormalizedPayload { get; set; }
         }
 
         private static void FillCommandInner(List<ParamValue> parameters, ref List<byte> data)

--- a/ZWaveXml/Application/ZWaveDefinitionExt.cs
+++ b/ZWaveXml/Application/ZWaveDefinitionExt.cs
@@ -712,17 +712,21 @@ namespace ZWave.Xml.Application
 
             var normalizeResult = NormalizeWithZWaveDefinition(payload, expectedCCVersion);
 
-            if (normalizeResult.Type == ParseResultType.Success)
+            if (normalizeResult.Success)
             {
                 var normalizedPayload = normalizeResult.NormalizedPayload;
                 result.NormalizedPayload = normalizedPayload;
-                result.Type = (normalizedPayload != null && normalizedPayload.Length != payload.Length)
-                    ? ParseResultType.LengthMismatch
-                    : ParseResultType.Success;
-            }
-            else
-            {
-                result.Type = normalizeResult.Type;
+
+                if(normalizedPayload == null)
+                {
+                    result.Type = ParseResultType.ParseFailed;
+                }
+                else
+                {
+                    result.Type = (normalizedPayload.Length != payload.Length)
+                        ? ParseResultType.LengthMismatch
+                        : ParseResultType.Success;
+                }
             }
 
             return result;
@@ -732,7 +736,7 @@ namespace ZWave.Xml.Application
         {
             var result = new NormalizeResult
             {
-                Type = ParseResultType.ParseFailed,
+                Success = false,
                 NormalizedPayload = null
             };
 
@@ -775,7 +779,7 @@ namespace ZWave.Xml.Application
                         return result;
                     }
 
-                    result.Type = ParseResultType.Success;
+                    result.Success = true;
                     result.NormalizedPayload = normalized;
 
                     return result;
@@ -791,7 +795,7 @@ namespace ZWave.Xml.Application
 
         private sealed class NormalizeResult
         {
-            public ParseResultType Type { get; set; }
+            public bool Success { get; set; }
             public byte[] NormalizedPayload { get; set; }
         }
 
@@ -860,9 +864,9 @@ namespace ZWave.Xml.Application
 
         public enum ParseResultType
         {
+            Success,
             LengthMismatch,
-            ParseFailed,
-            Success
+            ParseFailed
         }
     }
 }

--- a/ZWaveXml/Application/ZWaveDefinitionExt.cs
+++ b/ZWaveXml/Application/ZWaveDefinitionExt.cs
@@ -751,13 +751,13 @@ namespace ZWave.Xml.Application
                 }
 
                 byte cc = payload[0];
-                byte cmd = payload[1];
-                var candidates = values
+                byte? cmd = payload.Length > 1 ? payload[1] : (byte?)null;
+                List<CommandClassValue> candidates = values
                     .Where(v =>
                         v?.CommandClassDefinition != null &&
                         v.CommandValue?.CommandDefinition != null &&
                         v.CommandClassDefinition.KeyId == cc &&
-                        v.CommandValue.CommandDefinition.KeyId == cmd)
+                        (cmd == null || v.CommandValue.CommandDefinition.KeyId == cmd))
                     .ToList();
 
                 if (candidates.Count == 0)

--- a/ZWaveXml/Application/ZWaveDefinitionExt.cs
+++ b/ZWaveXml/Application/ZWaveDefinitionExt.cs
@@ -686,7 +686,7 @@ namespace ZWave.Xml.Application
             secureCommandClasses = secureCmdClasses.Count > 0 ? secureCmdClasses.ToArray() : null;
         }
 
-        public PayloadParseIssue ValidatePayloadLength(byte[] payload, byte expectedCCVersion, string sourceInfo = null)
+        public PayloadParseResult ValidatePayloadLength(byte[] payload, byte expectedCCVersion)
         {
             if (payload == null || payload.Length < 2)
                 return null;
@@ -694,47 +694,47 @@ namespace ZWave.Xml.Application
             byte cc = payload[0];
             byte cmd = payload[1];
 
-            if (!TryNormalizeWithZWaveDefinition(payload, expectedCCVersion, out byte[] normalized, out string details))
+            if (!TryNormalizeWithZWaveDefinition(payload, expectedCCVersion, out byte[] normalizedPayload, out ParseResultType resultType))
             {
-                var issue = new PayloadParseIssue
+                return new PayloadParseResult
                 {
-                    Type = ScriptParseIssueType.ParseFailed,
+                    Type = resultType,
                     CommandClassId = cc,
                     CommandId = cmd,
-                    PayloadLength = payload.Length,
-                    NormalizedLength = null,
-                    Payload = payload.ToArray(),
-                    Details = new List<string>() { details ??  "No parse candidate matched or normalization failed." },
-                    SourceInfo = sourceInfo
+                    CommandClassVersion = expectedCCVersion,
+                    OriginalPayload = payload,
+                    NormalizedPayload = null
                 };
-
-                return issue;
             }
 
-            if (normalized != null && normalized.Length != payload.Length)
+            if (normalizedPayload != null && normalizedPayload.Length != payload.Length)
             {
-                var issue = new PayloadParseIssue
+                return new PayloadParseResult
                 {
-                    Type = ScriptParseIssueType.TrailingBytes,
+                    Type = ParseResultType.LengthMismatch,
                     CommandClassId = cc,
                     CommandId = cmd,
-                    PayloadLength = payload.Length,
-                    NormalizedLength = normalized.Length,
-                    Payload = payload.ToArray(),
-                    Details = new List<string>() { "Received payload did not match the", "supported command class version." },
-                    SourceInfo = sourceInfo
+                    CommandClassVersion = expectedCCVersion,
+                    OriginalPayload = payload,
+                    NormalizedPayload = normalizedPayload
                 };
-
-                return issue;
             }
 
-            return null;
+            return new PayloadParseResult
+            {
+                Type = ParseResultType.Succsess,
+                CommandClassId = cc,
+                CommandId = cmd,
+                CommandClassVersion = expectedCCVersion,
+                OriginalPayload = payload,
+                NormalizedPayload = normalizedPayload
+            };
         }
 
-        private bool TryNormalizeWithZWaveDefinition(byte[] payload, byte expectedCCVersion, out byte[] normalized, out string details)
+        private bool TryNormalizeWithZWaveDefinition(byte[] payload, byte expectedCCVersion, out byte[] normalized, out ParseResultType resultType)
         {
             normalized = null;
-            details = null;
+            resultType = ParseResultType.ParseFailed;
 
             try
             {
@@ -743,7 +743,6 @@ namespace ZWave.Xml.Application
 
                 if (values == null || values.Length == 0)
                 {
-                    details = "ParseApplicationObject returned no values.";
                     return false;
                 }
 
@@ -759,7 +758,6 @@ namespace ZWave.Xml.Application
 
                 if (candidates.Count == 0)
                 {
-                    details = $"No parsed candidate matched CC=0x{cc:X2}, CMD=0x{cmd:X2}.";
                     return false;
                 }
 
@@ -774,22 +772,19 @@ namespace ZWave.Xml.Application
 
                     if (normalized == null || normalized.Length < 2)
                     {
-                        details = "FillCommand produced no valid payload.";
                         return false;
                     }
                 }
                 else
                 {
-                    var seenVersions = string.Join(",", candidates.Select(v => v.CommandClassDefinition.Version).Distinct().OrderBy(v => v));
-                    details = $"No candidate matched expected CC version {expectedCCVersion}. Seen versions: [{seenVersions}] for CC=0x{cc:X2}, CMD=0x{cmd:X2}.";
                     return false;
                 }
 
+                resultType = ParseResultType.Succsess;
                 return true;
             }
             catch (Exception ex)
             {
-                details = $"Normalization failed: {ex.Message}";
                 return false;
             }
         }
@@ -847,23 +842,22 @@ namespace ZWave.Xml.Application
             return ret.ToArray();
         }
 
-        public sealed class PayloadParseIssue
+        public sealed class PayloadParseResult
         {
-            public ScriptParseIssueType Type { get; set; }
+            public ParseResultType Type { get; set; }
+            public byte CommandClassVersion { get; set; }
             public byte CommandClassId { get; set; }
             public byte CommandId { get; set; }
-            public int PayloadLength { get; set; }
-            public int? NormalizedLength { get; set; }
-            public List<string> Details { get; set; }
-            public byte[] Payload { get; set; }
-            public DateTime TimestampUtc { get; set; } = DateTime.UtcNow;
-            public string SourceInfo { get; set; } // optional context (node/frame)
+            public byte[] OriginalPayload { get; set; }
+            public byte[] NormalizedPayload { get; set; }
         }
 
-        public enum ScriptParseIssueType
+        public enum ParseResultType
         {
-            TrailingBytes,
-            ParseFailed
+            LengthMismatch,
+            ParseFailed,
+            VersionMismatch,
+            Succsess
         }
     }
 }

--- a/ZWaveXml/Application/ZWaveDefinitionExt.cs
+++ b/ZWaveXml/Application/ZWaveDefinitionExt.cs
@@ -773,7 +773,7 @@ namespace ZWave.Xml.Application
                         candidate.CommandValue.CommandDefinition,
                         paramValues);
 
-                    if (normalized == null || normalized.Length < 2)
+                    if (normalized == null || normalized.Length < 1)
                     {
                         return result;
                     }

--- a/ZWaveXml/Application/ZWaveDefinitionExt.cs
+++ b/ZWaveXml/Application/ZWaveDefinitionExt.cs
@@ -705,7 +705,6 @@ namespace ZWave.Xml.Application
                 Type = PayloadParseResultType.ParseFailed, // default/fallback
                 CommandClassId = cc,
                 CommandId = cmd,
-                CommandClassVersion = expectedCCVersion,
                 OriginalPayload = payload,
                 NormalizedPayload = null
             };

--- a/ZWaveXml/Application/ZWaveDefinitionExt.cs
+++ b/ZWaveXml/Application/ZWaveDefinitionExt.cs
@@ -711,7 +711,7 @@ namespace ZWave.Xml.Application
 
             NormalizeResult normalizeResult = NormalizeWithZWaveDefinition(payload, expectedCCVersion);
 
-            if (normalizeResult.Success)
+            if (normalizeResult)
             {
                 byte[] normalizedPayload = normalizeResult.NormalizedPayload;
                 result.NormalizedPayload = normalizedPayload;


### PR DESCRIPTION
<!--
SPDX-License-Identifier: BSD-3-Clause
SPDX-FileCopyrightText: 2024 Z-Wave Alliance
-->

<!--
  This is a reminder that all Z-Wave Alliance activities are subject to strict
  compliance with the Z-Wave Antitrust Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/56)
  and IPR Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/43).
  Each individual contributor is responsible to know the contents of these documents
  and to comply with Policies. Copies of all governing documents are available on Causeway.

  Please, DO NOT DELETE ANY TEXT from this template unless instructed!
-->

## Related issue
<!--
  Mention the related issue as described in https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->
None

## Change
<!--
  Describe your changes below.
-->
feat: Implement length validation for commands.

Validates that a command's payload is matching a specific command class version
according to the Z-Wave definition. This can, for example, be used to verify
that a command is matching the supported version advertised by a device.

## Type of change
<!--
  What type of change does your PR introduce?
-->

- [x] New Feature
- [ ] Bug fix
- [ ] Editorial change
- [ ] Refactoring
- [ ] DevOps
- [ ] Breaking
- [ ] Other: (please describe)


## Checklist
<!--
  Please put an `x` in each box to make sure you follow the OSWG Guidelines.
-->

- [x] I have followed the [Contribution Guidelines][contribution-guidelines]
- [x] I agree to the [Developer Certificate of Origin][dco]
- [x] I have cleaned up my commits

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/contribution_guidelines.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
