### PR TITLE
fix: Allow 'Get Node Information Protocol Data' (0x41) for all devices.

### DIFF
--- a/BasicApplication/Devices/Controller.cs
+++ b/BasicApplication/Devices/Controller.cs
@@ -161,20 +161,6 @@ namespace ZWave.BasicApplication.Devices
             }
         }
 
-        #region GetProtocolInfo
-
-        public GetNodeProtocolInfoResult GetProtocolInfo(NodeTag node)
-        {
-            return (GetNodeProtocolInfoResult)Execute(new GetNodeProtocolInfoOperation(_network, node));
-        }
-
-        public ActionToken GetProtocolInfo(NodeTag node, Action<IActionItem> completedCallback)
-        {
-            return ExecuteAsync(new GetNodeProtocolInfoOperation(_network, node), completedCallback);
-        }
-
-        #endregion
-
         #region AddNodeToNetwork
 
         public AddRemoveNodeResult AddNodeToNetwork(Modes mode, int timeoutMs)

--- a/BasicApplication/Devices/Device.cs
+++ b/BasicApplication/Devices/Device.cs
@@ -885,6 +885,20 @@ namespace ZWave.BasicApplication.Devices
 
         #endregion
 
+        #region GetProtocolInfo
+
+        public GetNodeProtocolInfoResult GetProtocolInfo(NodeTag node)
+        {
+            return (GetNodeProtocolInfoResult)Execute(new GetNodeProtocolInfoOperation(Network, node));
+        }
+
+        public ActionToken GetProtocolInfo(NodeTag node, Action<IActionItem> completedCallback)
+        {
+            return ExecuteAsync(new GetNodeProtocolInfoOperation(Network, node), completedCallback);
+        }
+
+        #endregion
+
         #region MemoryGetId
 
         public MemoryGetIdResult MemoryGetId()


### PR DESCRIPTION
<!--
SPDX-License-Identifier: BSD-3-Clause
SPDX-FileCopyrightText: 2024 Z-Wave Alliance
-->

<!--
  This is a reminder that all Z-Wave Alliance activities are subject to strict
  compliance with the Z-Wave Antitrust Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/56)
  and IPR Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/43).
  Each individual contributor is responsible to know the contents of these documents
  and to comply with Policies. Copies of all governing documents are available on Causeway.

  Please, DO NOT DELETE ANY TEXT from this template unless instructed!
-->

## Related issue
<!--
  Mention the related issue as described in https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

none

## Change
<!--
  Describe your changes below.
-->

fix: Allow 'Get Node Information Protocol Data' (0x41) for all devices.

According to the Z-Wave Host API Spec, the operation is not restricted to
controllers only.

## Type of change
<!--
  What type of change does your PR introduce?
-->

- [x] New Feature
- [x] Bug fix
- [ ] Editorial change
- [ ] Refactoring
- [ ] DevOps
- [ ] Breaking
- [ ] Other: (please describe)


## Checklist
<!--
  Please put an `x` in each box to make sure you follow the OSWG Guidelines.
-->

- [x] I have followed the [Contribution Guidelines][contribution-guidelines]
- [x] I agree to the [Developer Certificate of Origin][dco]
- [x] I have cleaned up my commits

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/contribution_guidelines.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
