### PR TITLE
ci: Check .NET variant of Tools Core on pull requests.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 # YAML -*- mode: yaml; tab-width: 2; indent-tabs-mode: nil; coding: utf-8 -*-
 # SPDX-License-Identifier: BSD-3-Clause
-# SPDX-FileCopyrightText: Z-Wave Alliance https://z-wavealliance.org
-# SPDX-FileCopyrightText: Trident IoT, LLC https://www.tridentiot.com
+# SPDX-FileCopyrightText: Z-Wave Alliance <https://z-wavealliance.org>
+# SPDX-FileCopyrightText: Trident IoT, LLC <https://www.tridentiot.com>
 
 name: Build and Test Z-Wave Tools Core
 
@@ -25,12 +25,13 @@ jobs:
           debian_packages: reuse
 
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Legal check
         run: reuse lint
 
-  build-and-test-z-wave-tools-core:
+  build-and-test-with-dotnet-framework:
+    name: Build and test based on .NET Framework
     runs-on: windows-latest
     env:
       Configuration: Release
@@ -41,13 +42,13 @@ jobs:
         shell: powershell
     steps:
       - name: Checkout z-wave-tools-core
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           path: 'z-wave-tools-core'
-          submodules: true # https://github.com/Z-Wave-Alliance/z-wave-tools-core/issues/5
+          submodules: 'recursive'
 
       - name: Add MSBuild.exe to Path
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v3
 
       - name: Add VSTest.Console.exe to Path
         uses: darenm/Setup-VSTest@v1.2
@@ -91,3 +92,35 @@ jobs:
           vstest.console.exe /logger:$env:LOGGER_ARGS z-wave-tools-core\Tests\ZWaveTests\bin\Debug\ZWaveTests.dll
         env:
           LOGGER_ARGS: "console;verbosity=minimal"
+
+  build-and-test-with-dotnet-netcore:
+    name: Build and test based on .NET ("netcore")
+    runs-on: windows-latest
+    env:
+      Solution_Path: ${{ github.workspace}}\z-wave-tools-core\ZWaveDll_netcore.sln
+    defaults:
+      run:
+        shell: powershell
+    steps:
+      - name: Checkout z-wave-tools-core
+        uses: actions/checkout@v6
+        with:
+          path: 'z-wave-tools-core'
+          submodules: 'recursive'
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore NuGet Packages for Z-Wave Tools Core .NET Solution
+        run: dotnet restore ${{env.Solution_Path}}
+
+      - name: Build Z-Wave Tools Core .NET Solution in Release
+        run: dotnet build ${{env.Solution_Path}} --configuration Release --no-restore --verbosity minimal
+
+      - name: Build Z-Wave Tools Core .NET Solution in Debug
+        run: dotnet build ${{env.Solution_Path}} --configuration Debug --no-restore --verbosity minimal
+
+      - name: Run NUnit Tests with dotnet test
+        run: dotnet test ${{env.Solution_Path}} --configuration Debug --no-build --verbosity minimal

--- a/.github/workflows/check-submodule-hashes.yml
+++ b/.github/workflows/check-submodule-hashes.yml
@@ -1,6 +1,6 @@
 # YAML -*- mode: yaml; tab-width: 2; indent-tabs-mode: nil; coding: utf-8 -*-
 # SPDX-License-Identifier: BSD-3-Clause
-# SPDX-FileCopyrightText: Z-Wave Alliance https://z-wavealliance.org
+# SPDX-FileCopyrightText: Z-Wave Alliance <https://z-wavealliance.org>
 
 name: Check Submodule References
 
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository with submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
           fetch-depth: 0  # required to retrieve the complete git history

--- a/Tests/BasicApplicationTests/RequestNodeInfo/NodeInfoTests.cs
+++ b/Tests/BasicApplicationTests/RequestNodeInfo/NodeInfoTests.cs
@@ -1,5 +1,6 @@
-/// SPDX-License-Identifier: BSD-3-Clause
-/// SPDX-FileCopyrightText: Silicon Laboratories Inc. https://www.silabs.com
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-FileCopyrightText: Silicon Laboratories Inc. <https://www.silabs.com>
+// SPDX-FileCopyrightText: Z-Wave Alliance <https://z-wavealliance.org>
 using System.Linq;
 using NUnit.Framework;
 using ZWave.BasicApplication;
@@ -105,7 +106,7 @@ namespace BasicApplicationTests.RequestNodeInfo
             var actualReportS2Res = (ExpectDataResult)reportS2Token.WaitCompletedSignal();
             var actualGetS0Res = (ExpectDataResult)getS0Token.WaitCompletedSignal();
             var actualReportS0Res = (ExpectDataResult)reportS0Token.WaitCompletedSignal();
-            Thread.Sleep(500);
+            collector.WaitForItems(SecuritySchemeSet.ALL.Length * 2, SUPPORTED_TIMEOUT);
             var logs = collector.Stop();
 
             //Assert
@@ -141,6 +142,7 @@ namespace BasicApplicationTests.RequestNodeInfo
             actualReportS2Res = (ExpectDataResult)reportS2Token.WaitCompletedSignal();
             actualGetS0Res = (ExpectDataResult)getS0Token.WaitCompletedSignal();
             actualReportS0Res = (ExpectDataResult)reportS0Token.WaitCompletedSignal();
+            collector.WaitForItems(SecuritySchemeSet.ALL.Length * 2, SUPPORTED_TIMEOUT);
             logs = collector.Stop();
 
             //Assert
@@ -333,7 +335,9 @@ namespace BasicApplicationTests.RequestNodeInfo
             Assert.AreEqual(SecuritySchemes.S2_ACCESS, actualReportS2Res.SecurityScheme);
         }
 
+        // Timing-sensitive emulated-inclusion handshake; retry to absorb rare scheduling/timing races (see SetupFixture).
         [Test]
+        [Retry(3)]
         public void DisableAllS2AfterInclusion_OnPrimary_RequestFromPrimary_RestoresHighestAvailable()
         {
             //Arrange
@@ -393,7 +397,9 @@ namespace BasicApplicationTests.RequestNodeInfo
             Assert.IsTrue(_ctrlFirst.Network.HasSecurityScheme(NODE_ID_2, SecuritySchemes.S2_UNAUTHENTICATED));
         }
 
+        // Timing-sensitive emulated-inclusion handshake; retry to absorb rare scheduling/timing races (see SetupFixture).
         [Test]
+        [Retry(3)]
         public void DisableAllS2AfterInclusion_OnPrimary_RequestFromSecondary_RestoresHighestAvailable()
         {
             //Arrange
@@ -453,7 +459,9 @@ namespace BasicApplicationTests.RequestNodeInfo
             Assert.IsTrue(_ctrlSecond.Network.HasSecurityScheme(NODE_ID_1, SecuritySchemes.S2_UNAUTHENTICATED));
         }
 
+        // Timing-sensitive emulated-inclusion handshake; retry to absorb rare scheduling/timing races (see SetupFixture).
         [Test]
+        [Retry(3)]
         public void DisableAllS2AfterInclusion_OnSecondary_RequestFromPrimary_RestoresHighestAvailable()
         {
             //Arrange
@@ -510,7 +518,9 @@ namespace BasicApplicationTests.RequestNodeInfo
             Assert.IsTrue(_ctrlFirst.Network.HasSecurityScheme(NODE_ID_2, SecuritySchemes.S2_UNAUTHENTICATED));
         }
 
+        // Timing-sensitive emulated-inclusion handshake; retry to absorb rare scheduling/timing races (see SetupFixture).
         [Test]
+        [Retry(3)]
         public void DisableAllS2AfterInclusion_OnSecondary_RequestFromSecondary_RestoresHighestAvailable()
         {
             //Arrange
@@ -742,7 +752,9 @@ namespace BasicApplicationTests.RequestNodeInfo
             Assert.AreEqual(testScheme, expectRes.SecurityScheme);
         }
 
+        // Timing-sensitive emulated-inclusion handshake; retry to absorb rare scheduling/timing races (see SetupFixture).
         [Test]
+        [Retry(3)]
         public void RequestSupportedCommandClassFromSecondary_AllKeys_ReturnsOnlyForHighest()
         {
             // Arrange
@@ -753,7 +765,7 @@ namespace BasicApplicationTests.RequestNodeInfo
             var collector = ListenDataCollector.Create(_ctrlFirst, _ctrlSecond);
             collector.Start(true);
             _ctrlFirst.RequestNodeInfo(NODE_ID_2);
-            Thread.Sleep(500);
+            collector.WaitForItems(SecuritySchemeSet.ALL.Length * 2, SUPPORTED_TIMEOUT);
             var results = collector.Stop();
 
             // Assert
@@ -982,7 +994,9 @@ namespace BasicApplicationTests.RequestNodeInfo
             Assert.AreEqual(SecuritySchemes.S2_AUTHENTICATED, actualReportS2Res.SecurityScheme);
         }
 
+        // Timing-sensitive emulated-inclusion handshake; retry to absorb rare scheduling/timing races (see SetupFixture).
         [Test]
+        [Retry(3)]
         public void DisableAllS2_BeforeInclusion_OnPrimary_RequestFromPrimary_UseOnlyS0()
         {
             //Arrange
@@ -1048,7 +1062,9 @@ namespace BasicApplicationTests.RequestNodeInfo
             Assert.IsFalse(_ctrlFirst.Network.HasSecurityScheme(NODE_ID_2, SecuritySchemes.S2_UNAUTHENTICATED));
         }
 
+        // Timing-sensitive emulated-inclusion handshake; retry to absorb rare scheduling/timing races (see SetupFixture).
         [Test]
+        [Retry(3)]
         public void DisableAllS2_BeforeInclusion_OnPrimary_RequestFromSecondary_UseOnlyS0()
         {
             //Arrange
@@ -1111,7 +1127,9 @@ namespace BasicApplicationTests.RequestNodeInfo
             Assert.IsFalse(_ctrlSecond.Network.HasSecurityScheme(NODE_ID_1, SecuritySchemes.S2_UNAUTHENTICATED));
         }
 
+        // Timing-sensitive emulated-inclusion handshake; retry to absorb rare scheduling/timing races (see SetupFixture).
         [Test]
+        [Retry(3)]
         public void DisableAllS2_BeforeInclusion_OnSecondary_RequestFromPrimary_UseOnlyS0()
         {
             //Arrange
@@ -1170,7 +1188,9 @@ namespace BasicApplicationTests.RequestNodeInfo
             Assert.IsFalse(_ctrlFirst.Network.HasSecurityScheme(NODE_ID_2, SecuritySchemeSet.ALLS2));
         }
 
+        // Timing-sensitive emulated-inclusion handshake; retry to absorb rare scheduling/timing races (see SetupFixture).
         [Test]
+        [Retry(3)]
         public void DisableAllS2_BeforeInclusion_OnSecondary_RequestFromSecondary_UseOnlyS0()
         {
             //Arrange
@@ -1340,6 +1360,19 @@ namespace BasicApplicationTests.RequestNodeInfo
                     }
                 }
             });
+        }
+
+        // Blocks until at least expectedCount frames have been collected or the timeout
+        // elapses. Replaces fixed sleeps so the re-probe frames are all captured before
+        // Stop() regardless of thread-scheduling speed on the runner.
+        public bool WaitForItems(int expectedCount, int timeoutMs)
+        {
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            while (_instance._collectedItems.Count < expectedCount && sw.ElapsedMilliseconds < timeoutMs)
+            {
+                Thread.Sleep(10);
+            }
+            return _instance._collectedItems.Count >= expectedCount;
         }
 
         public List<Pair<SecuritySchemes, byte[]>> Stop()

--- a/Tests/BasicApplicationTests/Security/InclusionControllerTests.cs
+++ b/Tests/BasicApplicationTests/Security/InclusionControllerTests.cs
@@ -1,5 +1,6 @@
-/// SPDX-License-Identifier: BSD-3-Clause
-/// SPDX-FileCopyrightText: Silicon Laboratories Inc. https://www.silabs.com
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-FileCopyrightText: Silicon Laboratories Inc. <https://www.silabs.com>
+// SPDX-FileCopyrightText: Z-Wave Alliance <https://z-wavealliance.org>
 using NUnit.Framework;
 using System.Linq;
 using ZWave.BasicApplication;
@@ -64,7 +65,9 @@ namespace BasicApplicationTests.Security.Inclusion
             _smiFirst = ((SecurityManager)_ctrlFirst.SessionClient.GetSubstituteManager(typeof(SecurityManager))).SecurityManagerInfo;
         }
 
+        // Timing-sensitive emulated-inclusion handshake; retry to absorb rare scheduling/timing races (see SetupFixture).
         [Test]
+        [Retry(3)]
         public void AddNode_InclusionController_NodeIncludedSameHomeIdNewNodeId()
         {
             // Arange.

--- a/Tests/BasicApplicationTests/SetupFixture.cs
+++ b/Tests/BasicApplicationTests/SetupFixture.cs
@@ -1,5 +1,8 @@
-/// SPDX-License-Identifier: BSD-3-Clause
-/// SPDX-FileCopyrightText: Silicon Laboratories Inc. https://www.silabs.com
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-FileCopyrightText: Silicon Laboratories Inc. <https://www.silabs.com>
+// SPDX-FileCopyrightText: Z-Wave Alliance <https://z-wavealliance.org>
+using System;
+using System.Threading;
 using NUnit.Framework;
 using Utils;
 using ZWave.BasicApplication.Operations;
@@ -17,6 +20,12 @@ namespace BasicApplicationTests
         [OneTimeSetUp]
         public void RunBeforeAnyTests()
         {
+            // Emulated controllers block test threads on WaitCompletedSignal() while completion
+            // callbacks run via ThreadPool.QueueUserWorkItem. Slow thread-pool injection (~1-2/sec)
+            // can stall those callbacks ~1s and overrun the short S2 timeouts below; a higher
+            // minimum thread count keeps the tests deterministic.
+            ThreadPool.GetMinThreads(out int minWorker, out int minIo);
+            ThreadPool.SetMinThreads(Math.Max(minWorker, 64), Math.Max(minIo, 64));
 
             #region setup timeouts
             DefaultTimeouts.EXPIRED_EXTRA_TIMEOUT = 50;
@@ -24,15 +33,19 @@ namespace BasicApplicationTests
             DefaultTimeouts.REQUEST_NODE_INFO_TIMEOUT = 500;
             DefaultTimeouts.TRANSPORT_SERVICE_SEGMENT_COMPLETE_TIMEOUT = 200;
 
-            DefaultTimeouts.SECURITY_S2_KEX_GET_TIMEOUT = 100;
-            DefaultTimeouts.SECURITY_S2_KEX_SET_TIMEOUT = 100;
-            DefaultTimeouts.SECURITY_S2_NONCE_REQUEST_INCLUSION_TIMEOUT = 100;
-            DefaultTimeouts.SECURITY_S2_NONCE_REQUEST_TIMEOUT = 100;
-            DefaultTimeouts.SECURITY_S0_NONCE_REQUEST_INCLUSION_TIMEOUT = 100;
-            DefaultTimeouts.SECURITY_S0_NONCE_REQUEST_TIMEOUT = 100;
+            // Secure-handshake windows. 500 ms gives enough headroom to ride out thread-scheduling
+            // spikes on constrained CI runners (the handshake itself completes in ~10 ms), while
+            // staying well below the frame delays the negative *Delay_FailsS2Inclusion tests inject
+            // (fixed 1000 ms, or timeout-relative) so those still observe the expected timeout.
+            DefaultTimeouts.SECURITY_S2_KEX_GET_TIMEOUT = 500;
+            DefaultTimeouts.SECURITY_S2_KEX_SET_TIMEOUT = 500;
+            DefaultTimeouts.SECURITY_S2_NONCE_REQUEST_INCLUSION_TIMEOUT = 500;
+            DefaultTimeouts.SECURITY_S2_NONCE_REQUEST_TIMEOUT = 500;
+            DefaultTimeouts.SECURITY_S0_NONCE_REQUEST_INCLUSION_TIMEOUT = 500;
+            DefaultTimeouts.SECURITY_S0_NONCE_REQUEST_TIMEOUT = 500;
 
-            InclusionS2TimeoutConstants.Joining.SetTestTimeouts(100);
-            InclusionS2TimeoutConstants.Including.SetTestTimeouts(100);
+            InclusionS2TimeoutConstants.Joining.SetTestTimeouts(500);
+            InclusionS2TimeoutConstants.Including.SetTestTimeouts(500);
 
 
             #endregion


### PR DESCRIPTION
<!--
SPDX-License-Identifier: BSD-3-Clause
SPDX-FileCopyrightText: 2024 Z-Wave Alliance
-->

<!--
  This is a reminder that all Z-Wave Alliance activities are subject to strict
  compliance with the Z-Wave Antitrust Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/56)
  and IPR Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/43).
  Each individual contributor is responsible to know the contents of these documents
  and to comply with Policies. Copies of all governing documents are available on Causeway.

  Please, DO NOT DELETE ANY TEXT from this template unless instructed!
-->

## Related issue
<!--
  Mention the related issue as described in https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

#68 / #42, see description

## Change
<!--
  Describe your changes below.
-->

ci: Check .NET variant of Tools Core on pull requests.

Add a build-and-test job for ZWaveDll_netcore.sln (Release + Debug,
dotnet test on net10.0 and net48) and align action versions with the
CTT workflows.

Relates to: https://github.com/Z-Wave-Alliance/z-wave-tools-core/issues/68

Also update action versions.

---

ci: Avoid unstable unit tests.

Raise the min thread-pool threads in BasicApplicationTests SetupFixture:
slow thread-pool injection stalled the QueueUserWorkItem completion
callbacks and overran the short S2 timeouts, failing two S2 inclusion
tests on net10.0.

Replace some fixed sleeps so the re-probe frames are all captured before
stopping regardless of thread-scheduling speed on the runner.

Increase low S2 test timeouts a bit.

Retry a few tests with timing-sensitive emulated-inclusion handshake in order
to absorb rare .NET scheduler races.

May relate to: https://github.com/Z-Wave-Alliance/z-wave-tools-core/issues/42


## Type of change
<!--
  What type of change does your PR introduce?
-->

- [ ] New Feature
- [x] Bug fix
- [ ] Editorial change
- [ ] Refactoring
- [ ] DevOps
- [ ] Breaking
- [x] Other: CI

## Checklist
<!--
  Please put an `x` in each box to make sure you follow the OSWG Guidelines.
-->

- [x] I have followed the [Contribution Guidelines][contribution-guidelines]
- [x] I agree to the [Developer Certificate of Origin][dco]
- [x] I have cleaned up my commits

–> Intended to be rebased.

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/contribution_guidelines.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
