### PR TITLE
fix: Clarify that the payload length validation will only check for overlength.

### DIFF
--- a/ZWaveXml/Application/ZWaveDefinitionExt.cs
+++ b/ZWaveXml/Application/ZWaveDefinitionExt.cs
@@ -690,15 +690,15 @@ namespace ZWave.Xml.Application
         /// Validate a command's payload length is matching a specific command class version according to the Z-Wave definition.
         /// This can, for example, be used to verify a command is matching the supported version advertised by a device.
         /// </summary>
-        public PayloadParseResult ValidatePayloadLength(byte[] payload, byte expectedCCVersion)
+        public PayloadParseResult ValidatePayloadLength(byte[] origPayload, byte expectedCCVersion)
         {
-            if (payload == null || payload.Length < 1)
+            if (origPayload == null || origPayload.Length < 1)
             {
                 return null;
             }
 
-            byte cc = payload[0];
-            byte? cmd = payload.Length > 1 ? payload[1] : (byte?)null;
+            byte cc = origPayload[0];
+            byte? cmd = origPayload.Length > 1 ? origPayload[1] : (byte?)null;
 
             var result = new PayloadParseResult
             {
@@ -706,11 +706,11 @@ namespace ZWave.Xml.Application
                 CommandClassId = cc,
                 CommandClassVersion = expectedCCVersion,
                 CommandId = cmd,
-                OriginalPayload = payload,
+                OriginalPayload = origPayload,
                 NormalizedPayload = null
             };
 
-            NormalizeResult normalizeResult = NormalizeWithZWaveDefinition(payload, expectedCCVersion);
+            NormalizeResult normalizeResult = NormalizeWithZWaveDefinition(origPayload, expectedCCVersion);
 
             if (normalizeResult)
             {
@@ -723,7 +723,7 @@ namespace ZWave.Xml.Application
                 }
                 else
                 {
-                    result.Type = (normalizedPayload.Length != payload.Length)
+                    result.Type = (normalizedPayload.Length != origPayload.Length)
                         ? PayloadParseResultType.LengthMismatch
                         : PayloadParseResultType.Success;
                 }
@@ -732,7 +732,7 @@ namespace ZWave.Xml.Application
             return result;
         }
 
-        private NormalizeResult NormalizeWithZWaveDefinition(byte[] payload, byte expectedCCVersion)
+        private NormalizeResult NormalizeWithZWaveDefinition(byte[] origPayload, byte expectedCCVersion)
         {
             var result = new NormalizeResult
             {
@@ -743,15 +743,15 @@ namespace ZWave.Xml.Application
             try
             {
                 CommandClassValue[] values = null;
-                ParseApplicationObject(payload, out values);
+                ParseApplicationObject(origPayload, out values);
 
                 if (values == null || values.Length == 0)
                 {
                     return result;
                 }
 
-                byte cc = payload[0];
-                byte? cmd = payload.Length > 1 ? payload[1] : (byte?)null;
+                byte cc = origPayload[0];
+                byte? cmd = origPayload.Length > 1 ? origPayload[1] : (byte?)null;
                 List<CommandClassValue> candidates = values
                     .Where(v =>
                         v?.CommandClassDefinition != null &&

--- a/ZWaveXml/Application/ZWaveDefinitionExt.cs
+++ b/ZWaveXml/Application/ZWaveDefinitionExt.cs
@@ -717,15 +717,17 @@ namespace ZWave.Xml.Application
                 byte[] normalizedPayload = normalizeResult.NormalizedPayload;
                 result.NormalizedPayload = normalizedPayload;
 
-                if(normalizedPayload == null)
+                if (normalizedPayload == null || normalizedPayload.Length == 0)
                 {
                     result.Type = PayloadParseResultType.ParseFailed;
                 }
-                else
+                else if (origPayload.Length > normalizedPayload.Length)
                 {
-                    result.Type = (normalizedPayload.Length != origPayload.Length)
-                        ? PayloadParseResultType.LengthMismatch
-                        : PayloadParseResultType.Success;
+                    result.Type = PayloadParseResultType.PayloadTooLong;
+                }
+                else // Too short payload cannot be detected because the normalized payload cannot contain more than the original payload.
+                {
+                    result.Type = PayloadParseResultType.Success;
                 }
             }
 
@@ -874,7 +876,7 @@ namespace ZWave.Xml.Application
         public enum PayloadParseResultType
         {
             Success,
-            LengthMismatch,
+            PayloadTooLong,
             ParseFailed
         }
     }


### PR DESCRIPTION
<!--
SPDX-License-Identifier: BSD-3-Clause
SPDX-FileCopyrightText: 2024 Z-Wave Alliance
-->

<!--
  This is a reminder that all Z-Wave Alliance activities are subject to strict
  compliance with the Z-Wave Antitrust Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/56)
  and IPR Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/43).
  Each individual contributor is responsible to know the contents of these documents
  and to comply with Policies. Copies of all governing documents are available on Causeway.

  Please, DO NOT DELETE ANY TEXT from this template unless instructed!
-->

## Related issue
<!--
  Mention the related issue as described in https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

## Change
<!--
  Describe your changes below.
-->

### fix: Clarify that the payload length validation will only check for overlength.

Too short payload cannot be detected because the normalized payload cannot
contain more than the original payload.

---

### refactor: Clarify the original payload for the length validation.


## Type of change
<!--
  What type of change does your PR introduce?
-->

- [ ] New Feature
- [x] Bug fix
- [ ] Editorial change
- [x] Refactoring
- [ ] DevOps
- [ ] Breaking
- [ ] Other: (please describe)


## Checklist
<!--
  Please put an `x` in each box to make sure you follow the OSWG Guidelines.
-->

- [x] I have followed the [Contribution Guidelines][contribution-guidelines]
- [x] I agree to the [Developer Certificate of Origin][dco]
- [x] I have cleaned up my commits: **Intended for rebasing**

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/contribution_guidelines.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
