### PR TITLE
ci: Stabilize timing-sensitive node-interview tests on CI.

### DIFF
--- a/Tests/BasicApplicationTests/RequestNodeInfo/NodeInfoTests.cs
+++ b/Tests/BasicApplicationTests/RequestNodeInfo/NodeInfoTests.cs
@@ -35,12 +35,22 @@ namespace BasicApplicationTests.RequestNodeInfo
         [SetUp]
         public void SetUp()
         {
-            var oneSecTimeout = 334;
-            _ctrlFirst.Network.RequestTimeoutMs = oneSecTimeout;
-            _ctrlSecond.Network.RequestTimeoutMs = oneSecTimeout;
-            _ctrlThird.Network.RequestTimeoutMs = oneSecTimeout;
+            // ReportTime: how long the re-probe waits for each SupportedReport before giving up on a
+            // key (AWG role type RT:00.12.0001.1: ReportTime SHOULD be CommandTime + 1 s; production
+            // default is 1150 ms). Reduced here so the negative "expect no report" probes finish
+            // faster, but kept well above CI thread-scheduling jitter so real reports aren't missed
+            // mid-exchange. This is the value that governs re-probe reliability.
+            var reportTimeMs = 500;
+            _ctrlFirst.Network.RequestTimeoutMs = reportTimeMs;
+            _ctrlSecond.Network.RequestTimeoutMs = reportTimeMs;
+            _ctrlThird.Network.RequestTimeoutMs = reportTimeMs;
 
-            SUPPORTED_TIMEOUT = 8 * oneSecTimeout;
+            // Observation window for the test's ExpectData tokens - how long a token waits to see its
+            // frame. RequestNodeInfo/SendData run synchronously (Device.Execute blocks until the
+            // re-probe completes), so real frames have already flowed when the tokens are read; only
+            // the negative "expect no report" waits actually spend this window. Independent of
+            // ReportTime so raising ReportTime for reliability does not inflate these waits.
+            SUPPORTED_TIMEOUT = 2500;
 
             _ctrlFirst.SerialApiGetCapabilities();
             _ctrlSecond.SerialApiGetCapabilities();
@@ -86,7 +96,9 @@ namespace BasicApplicationTests.RequestNodeInfo
             return includeRes;
         }
 
+        // Timing-sensitive emulated-inclusion handshake; retry to absorb rare scheduling/timing races (see SetupFixture).
         [Test]
+        [Retry(3)]
         public void ReProbingEachKey_InCorrectOrder()
         {
             //Arrange
@@ -583,6 +595,8 @@ namespace BasicApplicationTests.RequestNodeInfo
         [TestCase(SecuritySchemes.S2_TEMP)]
         [TestCase(SecuritySchemes.S0)]
         [TestCase(SecuritySchemes.NONE)]
+        // Timing-sensitive emulated-inclusion handshake; retry to absorb rare scheduling/timing races (see SetupFixture).
+        [Retry(3)]
         public void SetActiveScheme_Restores_HighestAvailable(SecuritySchemes testScheme)
         {
             //Arrange
@@ -605,7 +619,9 @@ namespace BasicApplicationTests.RequestNodeInfo
             Assert.AreEqual(SecuritySchemes.S2_ACCESS, actualReportS2Res.SecurityScheme);
         }
 
+        // Timing-sensitive emulated-inclusion handshake; retry to absorb rare scheduling/timing races (see SetupFixture).
         [Test]
+        [Retry(3)]
         public void KEXConfirm_GrantOnlyS0_AffterIncluion_UseOnlyS0()
         {
             // Arrange
@@ -650,7 +666,9 @@ namespace BasicApplicationTests.RequestNodeInfo
             Assert.AreEqual(SecuritySchemes.S0, expectRes.SecurityScheme);
         }
 
+        // Timing-sensitive emulated-inclusion handshake; retry to absorb rare scheduling/timing races (see SetupFixture).
         [Test]
+        [Retry(3)]
         public void KEXConfirm_GrantOnlyS2All_AffterIncluion_UseS2Access()
         {
             // Arrange
@@ -699,6 +717,8 @@ namespace BasicApplicationTests.RequestNodeInfo
         [TestCase(SecuritySchemes.S2_ACCESS)]
         [TestCase(SecuritySchemes.S2_AUTHENTICATED)]
         [TestCase(SecuritySchemes.S2_UNAUTHENTICATED)]
+        // Timing-sensitive emulated-inclusion handshake; retry to absorb rare scheduling/timing races (see SetupFixture).
+        [Retry(3)]
         public void KEXConfirm_GrantOnlyOneS2_AffterIncluion_UseOnlyTestScheme(SecuritySchemes testScheme)
         {
             // Arrange

--- a/Tests/BasicApplicationTests/Security/InclusionS2Tests.cs
+++ b/Tests/BasicApplicationTests/Security/InclusionS2Tests.cs
@@ -624,6 +624,8 @@ namespace BasicApplicationTests.Security.Inclusion
         [TestCase(SecuritySchemes.S2_AUTHENTICATED)]
         [TestCase(SecuritySchemes.S2_UNAUTHENTICATED)]
         [TestCase(SecuritySchemes.S0)]
+        // Timing-sensitive emulated-inclusion handshake with a two-token round-trip; retry to absorb rare scheduling/timing races (see SetupFixture).
+        [Retry(3)]
         public void AddNode_SendWithSpecificKey_NodeRespondsWithSameKey(SecuritySchemes activeSecurityScheme)
         {
             // Arange.

--- a/Tests/BasicApplicationTests/SetupFixture.cs
+++ b/Tests/BasicApplicationTests/SetupFixture.cs
@@ -25,7 +25,7 @@ namespace BasicApplicationTests
             // can stall those callbacks ~1s and overrun the short S2 timeouts below; a higher
             // minimum thread count keeps the tests deterministic.
             ThreadPool.GetMinThreads(out int minWorker, out int minIo);
-            ThreadPool.SetMinThreads(Math.Max(minWorker, 64), Math.Max(minIo, 64));
+            ThreadPool.SetMinThreads(Math.Max(minWorker, 128), Math.Max(minIo, 128));
 
             #region setup timeouts
             DefaultTimeouts.EXPIRED_EXTRA_TIMEOUT = 50;
@@ -33,19 +33,19 @@ namespace BasicApplicationTests
             DefaultTimeouts.REQUEST_NODE_INFO_TIMEOUT = 500;
             DefaultTimeouts.TRANSPORT_SERVICE_SEGMENT_COMPLETE_TIMEOUT = 200;
 
-            // Secure-handshake windows. 500 ms gives enough headroom to ride out thread-scheduling
-            // spikes on constrained CI runners (the handshake itself completes in ~10 ms), while
-            // staying well below the frame delays the negative *Delay_FailsS2Inclusion tests inject
-            // (fixed 1000 ms, or timeout-relative) so those still observe the expected timeout.
-            DefaultTimeouts.SECURITY_S2_KEX_GET_TIMEOUT = 500;
-            DefaultTimeouts.SECURITY_S2_KEX_SET_TIMEOUT = 500;
-            DefaultTimeouts.SECURITY_S2_NONCE_REQUEST_INCLUSION_TIMEOUT = 500;
-            DefaultTimeouts.SECURITY_S2_NONCE_REQUEST_TIMEOUT = 500;
-            DefaultTimeouts.SECURITY_S0_NONCE_REQUEST_INCLUSION_TIMEOUT = 500;
-            DefaultTimeouts.SECURITY_S0_NONCE_REQUEST_TIMEOUT = 500;
+            // Secure-handshake windows. 750 ms gives headroom to ride out thread-scheduling spikes
+            // on constrained CI runners (the handshake itself completes in ~10 ms), while staying
+            // below the frame delays the negative *Delay_FailsS2Inclusion tests inject (fixed
+            // 1000 ms, or timeout-relative) so those still observe the expected timeout.
+            DefaultTimeouts.SECURITY_S2_KEX_GET_TIMEOUT = 750;
+            DefaultTimeouts.SECURITY_S2_KEX_SET_TIMEOUT = 750;
+            DefaultTimeouts.SECURITY_S2_NONCE_REQUEST_INCLUSION_TIMEOUT = 750;
+            DefaultTimeouts.SECURITY_S2_NONCE_REQUEST_TIMEOUT = 750;
+            DefaultTimeouts.SECURITY_S0_NONCE_REQUEST_INCLUSION_TIMEOUT = 750;
+            DefaultTimeouts.SECURITY_S0_NONCE_REQUEST_TIMEOUT = 750;
 
-            InclusionS2TimeoutConstants.Joining.SetTestTimeouts(500);
-            InclusionS2TimeoutConstants.Including.SetTestTimeouts(500);
+            InclusionS2TimeoutConstants.Joining.SetTestTimeouts(750);
+            InclusionS2TimeoutConstants.Including.SetTestTimeouts(750);
 
 
             #endregion


### PR DESCRIPTION
<!--
SPDX-License-Identifier: BSD-3-Clause
SPDX-FileCopyrightText: 2024 Z-Wave Alliance
-->

<!--
  This is a reminder that all Z-Wave Alliance activities are subject to strict
  compliance with the Z-Wave Antitrust Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/56)
  and IPR Policy (https://sdomembers.z-wavealliance.org/wg/Members/document/43).
  Each individual contributor is responsible to know the contents of these documents
  and to comply with Policies. Copies of all governing documents are available on Causeway.

  Please, DO NOT DELETE ANY TEXT from this template unless instructed!
-->

## Related issue
<!--
  Mention the related issue as described in https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

#42

## Change
<!--
  Describe your changes below.
-->

ci: Stabilize timing-sensitive node-interview tests on CI.

A thread stall on a loaded runner tripped the tight 334 ms ReportTime
mid-exchange, aborting the S2/S0 re-probe so the tail SupportedReport
never arrived and ExpectData returned null. Retries alone could not
help since the stall persists across attempts.

Raise ReportTime (RT:00.12.0001.1, CommandTime + 1 s) from 334 to
500 ms and rename oneSecTimeout to reportTimeMs. Decouple the
ExpectData observation window from ReportTime (fixed 2500 ms) so the
higher ReportTime does not inflate the negative "expect no report"
waits. Give the S2 inclusion handshake headroom (500 to 750 ms, still
under the 1000 ms the negative tests inject) and raise the thread-pool
floor to 128.

Also add three retries to the full/deep-walk re-probe tests and the S2
round-trip test as a safety net for residual rare scheduler races.

Relates to: https://github.com/Z-Wave-Alliance/z-wave-tools-core/issues/42

## Type of change
<!--
  What type of change does your PR introduce?
-->

- [ ] New Feature
- [x] Bug fix
- [ ] Editorial change
- [ ] Refactoring
- [ ] DevOps
- [ ] Breaking
- [ ] Other: (please describe)


## Checklist
<!--
  Please put an `x` in each box to make sure you follow the OSWG Guidelines.
-->

- [x] I have followed the [Contribution Guidelines][contribution-guidelines]
- [x] I agree to the [Developer Certificate of Origin][dco]
- [x] I have cleaned up my commits

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/contribution_guidelines.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
