### PR TITLE
feat: Sort Command Classes on load and save

### DIFF
--- a/ZWaveXml/Application/ZWaveDefinitionExt.cs
+++ b/ZWaveXml/Application/ZWaveDefinitionExt.cs
@@ -1,6 +1,6 @@
 /// SPDX-License-Identifier: BSD-3-Clause
 /// SPDX-FileCopyrightText: Silicon Laboratories Inc. <https://www.silabs.com>
-/// SPDX-FileCopyrightText: Z-Wave-Alliance <https://z-wavealliance.org>
+/// SPDX-FileCopyrightText: Z-Wave Alliance <https://z-wavealliance.org>
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -17,14 +17,72 @@ namespace ZWave.Xml.Application
             DefinitionConverter conv = new DefinitionConverter(path, null);
             conv.UpgradeConvert(false);
             var ret = conv.ZWaveDefinition;
+            SortCommandClasses(ret?.CommandClasses);
             return ret;
         }
 
         public static void Save(ZWaveDefinition zWaveDefinition, string path)
         {
+            SortCommandClasses(zWaveDefinition?.CommandClasses);
             DefinitionConverter conv = new DefinitionConverter(null, null) { ZWaveDefinition = zWaveDefinition };
             conv.DowngradeConvert();
             conv.SaveZXmlDefinition(path);
+        }
+
+        /// <summary>
+        /// Brings the Command Classes into the canonical order of the Z-Wave XML file.
+        ///
+        /// Versions of one Command Class share a Key but may have been renamed over
+        /// time, so they are grouped by Key and the whole group is placed by the
+        /// display name of its most recent version. Example: 'Command Class Alarm'
+        /// V1/V2 sort next to 'Command Class Notification' V8 under 'N', not 'A'.
+        /// Within a Command Class, the commands are ordered by their Key, not by name.
+        ///
+        /// Load and Save apply this, so every reader and writer of the file agrees on
+        /// the layout. The collection is reordered in place, which keeps bound
+        /// collections such as the Editor's tree view working on the same instance.
+        /// </summary>
+        /// <param name="commandClasses">Command Classes to reorder, may be null</param>
+        public static void SortCommandClasses(IList<CommandClass> commandClasses)
+        {
+            if (commandClasses == null || commandClasses.Count == 0)
+            {
+                return;
+            }
+
+            List<CommandClass> sorted = commandClasses
+                .GroupBy(cmdClass => cmdClass.KeyId)
+                .OrderBy(group => group.OrderByDescending(cmdClass => cmdClass.Version).First().Text,
+                    StringComparer.OrdinalIgnoreCase)
+                .ThenBy(group => group.Key)
+                .SelectMany(group => group.OrderBy(cmdClass => cmdClass.Version))
+                .ToList();
+
+            commandClasses.Clear();
+            foreach (var cmdClass in sorted)
+            {
+                SortCommands(cmdClass.Command);
+                commandClasses.Add(cmdClass);
+            }
+        }
+
+        /// <summary>
+        /// Orders the commands of a Command Class by their Key, in place.
+        /// </summary>
+        /// <param name="commands">Commands to reorder, may be null</param>
+        private static void SortCommands(IList<Command> commands)
+        {
+            if (commands == null || commands.Count < 2)
+            {
+                return;
+            }
+
+            List<Command> sorted = commands.OrderBy(cmd => cmd.KeyId).ToList();
+            commands.Clear();
+            foreach (var cmd in sorted)
+            {
+                commands.Add(cmd);
+            }
         }
 
         public static cmd_class DowngradeCommandClass(CommandClass cmdClass)


### PR DESCRIPTION
<!--
SPDX-License-Identifier: BSD-3-Clause
SPDX-FileCopyrightText: Z-Wave Alliance <https://z-wavealliance.org>
-->

<!--
  This is a reminder that all Z-Wave Alliance activities are subject to strict
  compliance with the Z-Wave Antitrust Policy and IPR Policy.
  Each individual contributor is responsible to know the contents of these documents
  and to comply with Policies. Copies of all governing documents are available on the SDO member portal.

  Please, DO NOT DELETE ANY TEXT from this template unless instructed!
-->

## Related Issue
<!--
  Mention the related issue as described in https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

https://github.com/Z-Wave-Alliance/z-wave-xml-tools/pull/28

## Change
<!--
  Describe your changes below.
-->

feat: Sort Command Classes on load and save

Load and Save bring the Command Classes into one canonical order, so
every reader and writer of the Z-Wave XML file agrees on its layout
instead of each tool sorting for itself.

Versions of one Command Class share a Key but may have been renamed, so
they are grouped by Key and the group is placed by the name of its most
recent version. 'Command Class Alarm' V1/V2 therefore sort next to
'Command Class Notification' V8 under 'N', not 'A'. Within a Command
Class the commands are ordered by their Key.

The reordering happens in place, so bound collections keep working on
the same instance.

## Type of change
<!--
  What type of change does your PR introduce?
-->

- [x] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Editorial change (`chore`, `docs`, `style`, etc.)
- [ ] Refactoring (`refactor`)
- [ ] DevOps (`chore`)
- [ ] Continuous integration (`ci`)
- [ ] Breaking (`!`, `BREAKING CHANGE`)
- [ ] Other (`build`, `perf`, `test`, etc.): (please describe)


## Checklist
<!--
  Please put an `x` in each box to make sure you follow the OSWG Guidelines.
-->

- [x] I have followed the [Contribution Guidelines][contribution-guidelines]
- [x] I agree to the [Developer Certificate of Origin][dco]

This PR is intended for:
- [x] Rebasing – I have cleaned up my commits.
- [ ] Squashing – The squash message should be: 
    ```
    (please describe)
    ```

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/CONTRIBUTING.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
