### PR TITLE
feat: Sort Command Classes on load and save

### DIFF
--- a/ZWaveXml/Application/ZWaveDefinitionExt.cs
+++ b/ZWaveXml/Application/ZWaveDefinitionExt.cs
@@ -1,6 +1,6 @@
 /// SPDX-License-Identifier: BSD-3-Clause
 /// SPDX-FileCopyrightText: Silicon Laboratories Inc. <https://www.silabs.com>
-/// SPDX-FileCopyrightText: Z-Wave-Alliance <https://z-wavealliance.org>
+/// SPDX-FileCopyrightText: Z-Wave Alliance <https://z-wavealliance.org>
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -17,14 +17,72 @@ namespace ZWave.Xml.Application
             DefinitionConverter conv = new DefinitionConverter(path, null);
             conv.UpgradeConvert(false);
             var ret = conv.ZWaveDefinition;
+            SortCommandClasses(ret?.CommandClasses);
             return ret;
         }
 
         public static void Save(ZWaveDefinition zWaveDefinition, string path)
         {
+            SortCommandClasses(zWaveDefinition?.CommandClasses);
             DefinitionConverter conv = new DefinitionConverter(null, null) { ZWaveDefinition = zWaveDefinition };
             conv.DowngradeConvert();
             conv.SaveZXmlDefinition(path);
+        }
+
+        /// <summary>
+        /// Brings the Command Classes into the canonical order of the Z-Wave XML file.
+        ///
+        /// Versions of one Command Class share a Key but may have been renamed over
+        /// time, so they are grouped by Key and the whole group is placed by the
+        /// display name of its most recent version. Example: 'Command Class Alarm'
+        /// V1/V2 sort next to 'Command Class Notification' V8 under 'N', not 'A'.
+        /// Within a Command Class, the commands are ordered by their Key, not by name.
+        ///
+        /// Load and Save apply this, so every reader and writer of the file agrees on
+        /// the layout. The collection is reordered in place, which keeps bound
+        /// collections such as the Editor's tree view working on the same instance.
+        /// </summary>
+        /// <param name="commandClasses">Command Classes to reorder, may be null</param>
+        public static void SortCommandClasses(IList<CommandClass> commandClasses)
+        {
+            if (commandClasses == null || commandClasses.Count == 0)
+            {
+                return;
+            }
+
+            List<CommandClass> sorted = commandClasses
+                .GroupBy(cmdClass => cmdClass.KeyId)
+                .OrderBy(group => group.OrderByDescending(cmdClass => cmdClass.Version).First().Text,
+                    StringComparer.OrdinalIgnoreCase)
+                .ThenBy(group => group.Key)
+                .SelectMany(group => group.OrderBy(cmdClass => cmdClass.Version))
+                .ToList();
+
+            commandClasses.Clear();
+            foreach (var cmdClass in sorted)
+            {
+                SortCommands(cmdClass.Command);
+                commandClasses.Add(cmdClass);
+            }
+        }
+
+        /// <summary>
+        /// Orders the commands of a Command Class by their Key, in place.
+        /// </summary>
+        /// <param name="commands">Commands to reorder, may be null</param>
+        private static void SortCommands(IList<Command> commands)
+        {
+            if (commands == null || commands.Count < 2)
+            {
+                return;
+            }
+
+            List<Command> sorted = commands.OrderBy(cmd => cmd.KeyId).ToList();
+            commands.Clear();
+            foreach (var cmd in sorted)
+            {
+                commands.Add(cmd);
+            }
         }
 
         public static cmd_class DowngradeCommandClass(CommandClass cmdClass)


### PR DESCRIPTION
## Related Issue

Requested in the review of Z-Wave-Alliance/z-wave-xml-tools#28. The XML Editor sorted the Command Classes for itself, so the ordering rule was not available to the Converter or to any other user of this library.

## Change

`Load` and `Save` bring the Command Classes into one canonical order, so every reader and writer of the Z-Wave XML file agrees on its layout instead of each tool sorting for itself.

### Ordering rule

Versions of one Command Class share a Key but may have been renamed over time, so they are grouped by Key and the whole group is placed by the 'Text' of its most recent version. Renamed Command Classes therefore stay together:

- `Command Class Alarm` V1/V2 sort next to `Command Class Notification` V8 under 'N', not under 'A'.
- `Command Class Multi Instance Association` V1 sorts next to `Command Class Multi Channel Association` V2-V5.

This matches how the specification documents group them. Within a Command Class, the commands are ordered by their Key, not by name.

The reordering happens in place, so bound collections keep working on the same instance. That is what lets the Editor's tree view show the new order without reloading the file.

### Effect on existing files

The first `Save` of a file that is not yet in this order rewrites it once. For the current `zwave.xml` (v2.19.1, 258 Command Classes) that touches 19170 of 19755 lines. No content is added or lost: the line count and the Command Class count are unchanged.

Afterwards the order is stable. Verified against that file:

- `Save` -> `Load` -> `Save` produces byte-identical output, so re-saving never churns the file.
- Every Key forms one contiguous block, versions ascend within each block, and commands ascend by Key in all Command Classes.
- `XmlConverter validate` exits 0 on the reordered file.

Until the one-time reordering commit lands in `z-wave-xml`, `XmlConverter validate` reports the difference and exits -1, because it compares the source bytes against a `Load`/`Save` round-trip. No CI workflow runs that command.

## Type of change

- [x] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Editorial change (`chore`, `docs`, `style`, etc.)
- [ ] Refactoring (`refactor`)
- [ ] DevOps (`chore`)
- [ ] Continuous integration (`ci`)
- [ ] Breaking (`!`, `BREAKING CHANGE`)
- [ ] Other (`build`, `perf`, `test`, etc.): (please describe)

## Checklist

- [x] I have followed the [Contribution Guidelines][contribution-guidelines]
- [ ] I agree to the [Developer Certificate of Origin][dco]

This PR is intended for:
- [x] Rebasing – I have cleaned up my commits.
- [ ] Squashing – The squash message should be: 
    ```
    (please describe)
    ```

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/CONTRIBUTING.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
