### PR TITLE
fix: Keep define sets of different types apart when converting.

### DIFF
--- a/ZWaveXml/DefinitionConverter.cs
+++ b/ZWaveXml/DefinitionConverter.cs
@@ -696,6 +696,13 @@ namespace ZWave.Xml
             string ret = null;
             foreach (var item in defineSetList)
             {
+                // The set Type decides how a parameter is written back (Full -> CONST,
+                // otherwise BYTE/bitflag) and whether the set reaches the C header, so sets
+                // of different types must never be shared even when their defines match.
+                if (item.Type != defineSet.Type)
+                {
+                    continue;
+                }
                 int mismatches = defineSet.Define.Count;
                 if (item.Define.Count != mismatches)
                 {


### PR DESCRIPTION
<!--
SPDX-License-Identifier: BSD-3-Clause
SPDX-FileCopyrightText: Z-Wave Alliance <https://z-wavealliance.org>
-->

<!--
  This is a reminder that all Z-Wave Alliance activities are subject to strict
  compliance with the Z-Wave Antitrust Policy and IPR Policy.
  Each individual contributor is responsible to know the contents of these documents
  and to comply with Policies. Copies of all governing documents are available on the SDO member portal.

  Please, DO NOT DELETE ANY TEXT from this template unless instructed!
-->

## Related Issue
<!--
  Mention the related issue as described in https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

https://github.com/Z-Wave-Alliance/z-wave-xml/pull/197#discussion_r3675696239

## Change
<!--
  Describe your changes below.
-->

fix: Keep define sets of different types apart when converting.

ContainDefineSet matched an existing define set on its contents alone,
ignoring the set Type. The Type decides how a parameter is written back -
Full yields CONST, anything else yields BYTE with bitflag children - so
sharing a set across types silently rewrites one of the parameters.

In User Credential Command Class, version 3, the User Type parameter
enumerates the same names and values as the Supported User Types Bit Mask.
The bit mask is parsed first and registers the set as Unknown, so both
CONST parameters are written back as BYTE on save.

Treat the Type as part of the set identity.

## Type of change
<!--
  What type of change does your PR introduce?
-->

- [ ] New feature (`feat`)
- [x] Bug fix (`fix`)
- [ ] Editorial change (`chore`, `docs`, `style`, etc.)
- [ ] Refactoring (`refactor`)
- [ ] DevOps (`chore`)
- [ ] Continuous integration (`ci`)
- [ ] Breaking (`!`, `BREAKING CHANGE`)
- [ ] Other (`build`, `perf`, `test`, etc.): (please describe)


## Checklist
<!--
  Please put an `x` in each box to make sure you follow the OSWG Guidelines.
-->

- [x] I have followed the [Contribution Guidelines][contribution-guidelines]
- [x] I agree to the [Developer Certificate of Origin][dco]

This PR is intended for:
- [x] Rebasing – I have cleaned up my commits.
- [ ] Squashing – The squash message should be: 
    ```
    (please describe)
    ```

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/CONTRIBUTING.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
