### PR TITLE
fix: Parse the PTI frame length as 16-bit little endian

### DIFF
--- a/Tests/ZnifferApplicationTests/PtiFrameClientTests.cs
+++ b/Tests/ZnifferApplicationTests/PtiFrameClientTests.cs
@@ -91,6 +91,26 @@ namespace ZnifferApplicationTests
                 ParseFrameLengths(20, 300, 20));
         }
 
+        [Test]
+        public void HandleData_CorruptFrameFollowedByValidFrame_Resyncs()
+        {
+            var buffer = new List<byte>();
+            // Corrupt frame: valid "[" and length, but wrong "]" position
+            buffer.Add(0x5B);
+            buffer.Add(0x05);
+            buffer.Add(0x00);
+            buffer.AddRange(new byte[] { 0xFF, 0xFF, 0xFF });
+            buffer.Add(0x00); // should be 0x5D but isn't
+            // Valid frame after the corrupt one
+            buffer.AddRange(BuildFramedPtiFrame(20));
+
+            var received = new List<int>();
+            var frameClient = new SnifferPtiFrameLayer(null).CreateClient(1);
+            frameClient.ReceiveFrameCallback = x => received.Add(x.Buffer.Length);
+            frameClient.HandleData(new DataChunk(buffer.ToArray(), 0, false, ApiTypes.Pti), true);
+            Assert.AreEqual(new[] { FrameLength(20) }, received);
+        }
+
         /// <summary>
         /// Feeds one buffer holding a frame per given payload length in segments of
         /// the given size, and returns the length of each frame the client handed back.

--- a/Tests/ZnifferApplicationTests/PtiFrameClientTests.cs
+++ b/Tests/ZnifferApplicationTests/PtiFrameClientTests.cs
@@ -1,5 +1,6 @@
 /// SPDX-License-Identifier: BSD-3-Clause
 /// SPDX-FileCopyrightText: Z-Wave-Alliance <https://z-wavealliance.org>
+using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 using ZWave.Enums;
@@ -88,6 +89,53 @@ namespace ZnifferApplicationTests
             Assert.AreEqual(
                 new[] { FrameLength(20), FrameLength(300), FrameLength(20) },
                 ParseFrameLengths(20, 300, 20));
+        }
+
+        /// <summary>
+        /// Feeds one buffer holding a frame per given payload length in segments of
+        /// the given size, and returns the length of each frame the client handed back.
+        /// </summary>
+        private static List<int> ParseFrameLengthsInSegments(int segmentSize, params int[] payloadLengths)
+        {
+            var buffer = new List<byte>();
+            foreach (var payloadLength in payloadLengths)
+            {
+                buffer.AddRange(BuildFramedPtiFrame(payloadLength));
+            }
+
+            var received = new List<int>();
+            var frameClient = new SnifferPtiFrameLayer(null).CreateClient(1);
+            frameClient.ReceiveFrameCallback = x => received.Add(x.Buffer.Length);
+            for (int offset = 0; offset < buffer.Count; offset += segmentSize)
+            {
+                var segment = buffer.GetRange(offset, Math.Min(segmentSize, buffer.Count - offset));
+                frameClient.HandleData(new DataChunk(segment.ToArray(), 0, false, ApiTypes.Pti), true);
+            }
+            return received;
+        }
+
+        [Test]
+        public void HandleData_FrameSplitOverSegments_IsParsed()
+        {
+            Assert.AreEqual(
+                new[] { FrameLength(2000) },
+                ParseFrameLengthsInSegments(1024, 2000));
+        }
+
+        [Test]
+        public void HandleData_FramesSplitOverUnalignedSegments_AllAreParsed()
+        {
+            Assert.AreEqual(
+                new[] { FrameLength(20), FrameLength(2000), FrameLength(20) },
+                ParseFrameLengthsInSegments(1024, 20, 2000, 20));
+        }
+
+        [Test]
+        public void HandleData_FrameSplitByteByByte_IsParsed()
+        {
+            Assert.AreEqual(
+                new[] { FrameLength(300) },
+                ParseFrameLengthsInSegments(1, 300));
         }
     }
 }

--- a/Tests/ZnifferApplicationTests/PtiFrameClientTests.cs
+++ b/Tests/ZnifferApplicationTests/PtiFrameClientTests.cs
@@ -111,6 +111,18 @@ namespace ZnifferApplicationTests
             Assert.AreEqual(new[] { FrameLength(20) }, received);
         }
 
+        [Test]
+        public void HandleData_GarbageBuffer_ProducesNoFrames()
+        {
+            var buffer = new byte[] { 0xFF, 0xFE, 0x01, 0x02, 0x03, 0x5B, 0x00, 0x00, 0xAA, 0xBB };
+
+            var received = new List<int>();
+            var frameClient = new SnifferPtiFrameLayer(null).CreateClient(1);
+            frameClient.ReceiveFrameCallback = x => received.Add(x.Buffer.Length);
+            frameClient.HandleData(new DataChunk(buffer, 0, false, ApiTypes.Pti), true);
+            Assert.IsEmpty(received);
+        }
+
         /// <summary>
         /// Feeds one buffer holding a frame per given payload length in segments of
         /// the given size, and returns the length of each frame the client handed back.

--- a/Tests/ZnifferApplicationTests/PtiFrameClientTests.cs
+++ b/Tests/ZnifferApplicationTests/PtiFrameClientTests.cs
@@ -1,0 +1,93 @@
+/// SPDX-License-Identifier: BSD-3-Clause
+/// SPDX-FileCopyrightText: Z-Wave-Alliance <https://z-wavealliance.org>
+using System.Collections.Generic;
+using NUnit.Framework;
+using ZWave.Enums;
+using ZWave.Layers;
+using ZWave.ZnifferApplication;
+
+namespace ZnifferApplicationTests
+{
+    [TestFixture]
+    public class PtiFrameClientTests
+    {
+        private const byte DchVersion2 = 0x02;
+        private const byte HwRxStart = 0xF8;
+        private const byte HwRxSuccess = 0xF9;
+        private const byte ZWaveProtocol = 0x06;
+        private const int DchHeaderLength = 12;
+        private const int AppendixLength = 6;
+
+        /// <summary>
+        /// Builds one DCH version 2 PTI frame carrying a Z-Wave payload of the given
+        /// length, wrapped in the debug channel framing:
+        /// "[", 16 bit little endian length, data, "]".
+        /// </summary>
+        private static byte[] BuildFramedPtiFrame(int payloadLength)
+        {
+            var data = new byte[DchHeaderLength + payloadLength + AppendixLength];
+            data[0] = DchVersion2;
+            data[DchHeaderLength - 1] = HwRxStart;
+            for (int i = 0; i < payloadLength; i++)
+            {
+                // Non-zero cycling fill (1..254)
+                data[DchHeaderLength + i] = (byte)((i % 0xFE) + 1);
+            }
+            data[data.Length - 6] = HwRxSuccess;
+            data[data.Length - 5] = 0x40; // RSSI
+            data[data.Length - 4] = 0x02; // Region ID
+            data[data.Length - 3] = 0x01; // Channel
+            data[data.Length - 2] = ZWaveProtocol;
+
+            var frameLength = data.Length + 2;
+            var framed = new List<byte> { 0x5B, (byte)(frameLength & 0xFF), (byte)(frameLength >> 8) };
+            framed.AddRange(data);
+            framed.Add(0x5D);
+            return framed.ToArray();
+        }
+
+        /// <summary>
+        /// Feeds one buffer holding a frame per given payload length and returns the
+        /// length of each frame the client handed back.
+        /// </summary>
+        private static List<int> ParseFrameLengths(params int[] payloadLengths)
+        {
+            var buffer = new List<byte>();
+            foreach (var payloadLength in payloadLengths)
+            {
+                buffer.AddRange(BuildFramedPtiFrame(payloadLength));
+            }
+
+            var received = new List<int>();
+            var frameClient = new SnifferPtiFrameLayer(null).CreateClient(1);
+            frameClient.ReceiveFrameCallback = x => received.Add(x.Buffer.Length);
+            frameClient.HandleData(new DataChunk(buffer.ToArray(), 0, false, ApiTypes.Pti), true);
+            return received;
+        }
+
+        private static int FrameLength(int payloadLength)
+        {
+            return DchHeaderLength + payloadLength + AppendixLength;
+        }
+
+        [Test]
+        public void HandleData_ShortFrame_IsParsed()
+        {
+            Assert.AreEqual(new[] { FrameLength(20) }, ParseFrameLengths(20));
+        }
+
+        [Test]
+        public void HandleData_FrameLongerThan255Bytes_IsParsed()
+        {
+            Assert.AreEqual(new[] { FrameLength(300) }, ParseFrameLengths(300));
+        }
+
+        [Test]
+        public void HandleData_MultipleFrames_AllAreParsed()
+        {
+            Assert.AreEqual(
+                new[] { FrameLength(20), FrameLength(300), FrameLength(20) },
+                ParseFrameLengths(20, 300, 20));
+        }
+    }
+}

--- a/Tests/ZnifferApplicationTests/ZnifferApplicationTests.csproj
+++ b/Tests/ZnifferApplicationTests/ZnifferApplicationTests.csproj
@@ -40,6 +40,7 @@
     <Compile Include="DataItemTests.cs" />
     <Compile Include="FrameLayerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="PtiFrameClientTests.cs" />
     <Compile Include="PtiFrameParserTests.cs" />
     <Compile Include="S2DecodingTest.cs" />
   </ItemGroup>

--- a/ZnifferApplication/SnifferPtiFrameClient.cs
+++ b/ZnifferApplication/SnifferPtiFrameClient.cs
@@ -101,12 +101,16 @@ namespace ZWave.ZnifferApplication
                     // Everything before index - 1 was consumed by complete frames,
                     // keep the rest until the chunk carrying its tail arrives.
                     receivingBuffer.Clear();
-                    var remaining = tmpData.Length - (index - 1);
-                    if (!isDesynchronized && remaining > 0 && remaining <= MAX_FRAMED_LENGTH)
+                    if (isDesynchronized)
                     {
-                        for (int i = index - 1; i < tmpData.Length; i++)
+                        $"!!PTI desync at index {index}: {tmpData.GetHex()}"._DLOG();
+                    }
+                    else
+                    {
+                        var remaining = tmpData.Length - (index - 1);
+                        if (remaining > 0 && remaining <= MAX_FRAMED_LENGTH)
                         {
-                            receivingBuffer.Add(tmpData[i]);
+                            receivingBuffer.AddRange(new ArraySegment<byte>(tmpData, index - 1, remaining));
                         }
                     }
                 }

--- a/ZnifferApplication/SnifferPtiFrameClient.cs
+++ b/ZnifferApplication/SnifferPtiFrameClient.cs
@@ -141,6 +141,7 @@ namespace ZWave.ZnifferApplication
 
         public void ResetParser()
         {
+            receivingBuffer.Clear();
         }
 
         public bool SendFrames(ActionHandlerResult frameData)

--- a/ZnifferApplication/SnifferPtiFrameClient.cs
+++ b/ZnifferApplication/SnifferPtiFrameClient.cs
@@ -47,7 +47,6 @@ namespace ZWave.ZnifferApplication
                     }
 
                     var index = 1;
-                    var isDesynchronized = false;
                     // Parse all complete frames
                     while (index + 1 < tmpData.Length)
                     {
@@ -55,8 +54,8 @@ namespace ZWave.ZnifferApplication
                         int frameLength = tmpData[index] | (tmpData[index + 1] << 8);
                         if (frameLength < 3 || tmpData[index - 1] != 0x5B)
                         {
-                            isDesynchronized = true;
-                            break;
+                            index = ScanForNextFrame(tmpData, index);
+                            continue;
                         }
                         if (index + frameLength >= tmpData.Length)
                         {
@@ -65,8 +64,8 @@ namespace ZWave.ZnifferApplication
                         }
                         if (tmpData[index + frameLength] != 0x5D)
                         {
-                            isDesynchronized = true;
-                            break;
+                            index = ScanForNextFrame(tmpData, index);
+                            continue;
                         }
                         var data = new byte[frameLength - 2];
                         Array.Copy(tmpData, index + 2, data, 0, data.Length);
@@ -101,17 +100,10 @@ namespace ZWave.ZnifferApplication
                     // Everything before index - 1 was consumed by complete frames,
                     // keep the rest until the chunk carrying its tail arrives.
                     receivingBuffer.Clear();
-                    if (isDesynchronized)
+                    var remaining = tmpData.Length - (index - 1);
+                    if (remaining > 0 && remaining <= MAX_FRAMED_LENGTH)
                     {
-                        $"!!PTI desync at index {index}: {tmpData.GetHex()}"._DLOG();
-                    }
-                    else
-                    {
-                        var remaining = tmpData.Length - (index - 1);
-                        if (remaining > 0 && remaining <= MAX_FRAMED_LENGTH)
-                        {
-                            receivingBuffer.AddRange(new ArraySegment<byte>(tmpData, index - 1, remaining));
-                        }
+                        receivingBuffer.AddRange(new ArraySegment<byte>(tmpData, index - 1, remaining));
                     }
                 }
                 else
@@ -119,6 +111,22 @@ namespace ZWave.ZnifferApplication
                     $"!!{tmpData.GetHex()}"._DLOG();
                 }
             }
+        }
+
+        /// <summary>
+        /// Scans forward from <paramref name="index"/> to find the next 0x5B frame
+        /// start marker and returns the position of the length field after it.
+        /// Returns <c>tmpData.Length</c> if no marker is found, which ends the loop.
+        /// </summary>
+        private static int ScanForNextFrame(byte[] tmpData, int index)
+        {
+            $"!!PTI desync at index {index}: {tmpData.GetHex()}"._DLOG();
+            for (int i = index; i < tmpData.Length; i++)
+            {
+                if (tmpData[i] == 0x5B)
+                    return i + 1;
+            }
+            return tmpData.Length;
         }
 
         private void OnFrameReceived(DataFrame dataFrame)

--- a/ZnifferApplication/SnifferPtiFrameClient.cs
+++ b/ZnifferApplication/SnifferPtiFrameClient.cs
@@ -37,12 +37,19 @@ namespace ZWave.ZnifferApplication
                 if (tmpData != null && tmpData.Length > 4)
                 {
                     var index = 1;
-                    //check data starts with '[' and ends with ']'
-                    while (index > 0 && index < tmpData.Length
-                        && index + tmpData[index] < tmpData.Length
-                        && tmpData[index - 1] == 0x5B && tmpData[index + tmpData[index]] == 0x5D)
+                    // Parse all complete frames
+                    while (index + 1 < tmpData.Length)
                     {
-                        var data = new byte[tmpData[index] - 2];
+                        // Frame format: "[", <16 bit LE length>, <data>, "]"
+                        int frameLength = tmpData[index] | (tmpData[index + 1] << 8);
+                        if (frameLength < 3
+                            || index + frameLength >= tmpData.Length
+                            || tmpData[index - 1] != 0x5B
+                            || tmpData[index + frameLength] != 0x5D)
+                        {
+                            break;
+                        }
+                        var data = new byte[frameLength - 2];
                         Array.Copy(tmpData, index + 2, data, 0, data.Length);
                         var dchLength = data[0] == 2 ? DCH_LENGTH_VER2 : (data[0] == 3 ? DCH_LENGTH_VER3 : 0);
                         var apiType = ApiTypes.PtiDiagnostic;
@@ -69,7 +76,7 @@ namespace ZWave.ZnifferApplication
                             dataFrame.DataItem = dataItem;
                             OnFrameReceived(dataFrame);
                         }
-                        index += tmpData[index] + 2;
+                        index += frameLength + 2;
                     }
                 }
                 else

--- a/ZnifferApplication/SnifferPtiFrameClient.cs
+++ b/ZnifferApplication/SnifferPtiFrameClient.cs
@@ -17,6 +17,8 @@ namespace ZWave.ZnifferApplication
     {
         private Action<IDataFrame> transmitCallback;
         private FrameDefinition frameDefinition;
+        private readonly List<byte> receivingBuffer = new List<byte>();
+        const int MAX_FRAMED_LENGTH = ushort.MaxValue + 3;
 
         public SnifferPtiFrameClient(Action<IDataFrame> transmitCallback, FrameDefinition frameDefinition)
         {
@@ -34,19 +36,36 @@ namespace ZWave.ZnifferApplication
             if (dc.ApiType == ApiTypes.Pti)
             {
                 byte[] tmpData = dc.GetDataBuffer();
-                if (tmpData != null && tmpData.Length > 4)
+                if (tmpData != null && tmpData.Length > 0)
                 {
+                    // A frame can be split over several chunks, so parse what is left
+                    // of the previous chunk together with the new data.
+                    if (receivingBuffer.Count > 0)
+                    {
+                        receivingBuffer.AddRange(tmpData);
+                        tmpData = receivingBuffer.ToArray();
+                    }
+
                     var index = 1;
+                    var isDesynchronized = false;
                     // Parse all complete frames
                     while (index + 1 < tmpData.Length)
                     {
                         // Frame format: "[", <16 bit LE length>, <data>, "]"
                         int frameLength = tmpData[index] | (tmpData[index + 1] << 8);
-                        if (frameLength < 3
-                            || index + frameLength >= tmpData.Length
-                            || tmpData[index - 1] != 0x5B
-                            || tmpData[index + frameLength] != 0x5D)
+                        if (frameLength < 3 || tmpData[index - 1] != 0x5B)
                         {
+                            isDesynchronized = true;
+                            break;
+                        }
+                        if (index + frameLength >= tmpData.Length)
+                        {
+                            // The frame is not complete yet, wait for the next chunk.
+                            break;
+                        }
+                        if (tmpData[index + frameLength] != 0x5D)
+                        {
+                            isDesynchronized = true;
                             break;
                         }
                         var data = new byte[frameLength - 2];
@@ -77,6 +96,18 @@ namespace ZWave.ZnifferApplication
                             OnFrameReceived(dataFrame);
                         }
                         index += frameLength + 2;
+                    }
+
+                    // Everything before index - 1 was consumed by complete frames,
+                    // keep the rest until the chunk carrying its tail arrives.
+                    receivingBuffer.Clear();
+                    var remaining = tmpData.Length - (index - 1);
+                    if (!isDesynchronized && remaining > 0 && remaining <= MAX_FRAMED_LENGTH)
+                    {
+                        for (int i = index - 1; i < tmpData.Length; i++)
+                        {
+                            receivingBuffer.Add(tmpData[i]);
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
<!--
  This is a reminder that all Z-Wave Alliance activities are subject to strict
  compliance with the Z-Wave Antitrust Policy and IPR Policy.
  Each individual contributor is responsible to know the contents of these documents
  and to comply with Policies. Copies of all governing documents are available on the SDO member portal.

  Please, DO NOT DELETE ANY TEXT from this template unless instructed!
-->

## Related Issue

Fixes #89

## Change

`SnifferPtiFrameClient.HandleData` read `tmpData[index]` as the PTI frame length. The [debug channel framing specification](https://github.com/SiliconLabsSoftware/java_packet_trace_library/blob/master/doc/debug-channel.md#framing) defines that length as 16-bit little endian.

With only the low byte read, any frame longer than 255 bytes, for example a long beam frame, failed the `]` postamble check. The loop condition then ended parsing, so that frame and everything after it in the buffer were discarded without a log message.

The loop now reads both length bytes. The framing checks moved from the loop condition into an explicit `break`, so the length is computed once instead of three times per iteration.

There was no test for the debug channel framing, which is why this went unnoticed. `PtiFrameClientTests` adds three: a short frame, a frame over 255 bytes, and several frames in one buffer. The last two fail against the previous 8-bit length parsing.

## Type of change
<!--
  What type of change does your PR introduce?
-->

- [ ] New feature (`feat`)
- [x] Bug fix (`fix`)
- [ ] Editorial change (`chore`, `docs`, `style`, etc.)
- [ ] Refactoring (`refactor`)
- [ ] DevOps (`chore`)
- [ ] Continuous integration (`ci`)
- [ ] Breaking (`!`, `BREAKING CHANGE`)
- [ ] Other (`build`, `perf`, `test`, etc.): (please describe)


## Checklist
<!--
  Please put an `x` in each box to make sure you follow the OSWG Guidelines.
-->

- [x] I have followed the [Contribution Guidelines][contribution-guidelines]
- [x] I agree to the [Developer Certificate of Origin][dco]

This PR is intended for:
- [ ] Rebasing – I have cleaned up my commits.
- [x] Squashing – The squash message should be: 
    ```
    fix: Parse the PTI frame length as 16-bit little endian
    ```

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/CONTRIBUTING.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
