### PR TITLE
fix: Widen the PTI region ID mask to 5 bits

### DIFF
--- a/Tests/ZnifferApplicationTests/PtiFrameParserTests.cs
+++ b/Tests/ZnifferApplicationTests/PtiFrameParserTests.cs
@@ -1,0 +1,81 @@
+/// SPDX-License-Identifier: BSD-3-Clause
+/// SPDX-FileCopyrightText: Z-Wave-Alliance <https://z-wavealliance.org>
+using System;
+using NUnit.Framework;
+using ZWave.Enums;
+using ZWave.ZnifferApplication;
+
+namespace ZnifferApplicationTests
+{
+    [TestFixture]
+    public class PtiFrameParserTests
+    {
+        private const byte DchVersion2 = 0x02;
+        private const byte HwRxStart = 0xF8;
+        private const byte HwRxSuccess = 0xF9;
+        private const byte ZWaveProtocol = 0x06;
+        private const int DchHeaderLength = 12;
+        private const int AppendixLength = 6;
+
+        private const byte RegionEu = 0x01;
+        private const byte RegionUsLr3 = 0x0E;
+        private const byte RegionEuLr1 = 0x0F;
+        private const byte RegionEuLr2 = 0x10;
+        private const byte RegionEuLr3 = 0x11;
+
+        private const byte Speed9600 = 0;
+        private const byte Speed40K = 1;
+        private const byte Speed100K = 2;
+        private const byte SpeedLr = 3;
+
+        /// Builds one DCH version 2 PTI frame received on <paramref name="channel"/>
+        /// of <paramref name="region"/>, carrying a 10 byte Z-Wave payload.
+        private static byte[] BuildPtiFrame(byte region, byte channel)
+        {
+            var data = new byte[DchHeaderLength + 10 + AppendixLength];
+            data[0] = DchVersion2;
+            data[DchHeaderLength - 1] = HwRxStart;
+            for (int i = 0; i < 10; i++)
+            {
+                // Stay clear of 0x55, which marks a beam and parses differently
+                data[DchHeaderLength + i] = (byte)(i + 1);
+            }
+            data[data.Length - 6] = HwRxSuccess;
+            data[data.Length - 5] = 0x40; // RSSI
+            data[data.Length - 4] = region;
+            data[data.Length - 3] = channel;
+            data[data.Length - 2] = ZWaveProtocol;
+            return data;
+        }
+
+        private static DataItem Parse(byte region, byte channel)
+        {
+            return PtiFrameParser.GetDataItem(
+                ApiTypes.Pti, DateTime.Now, null, 1, BuildPtiFrame(region, channel));
+        }
+
+        [TestCase(RegionEuLr2, 3)]
+        [TestCase(RegionEuLr3, 0)]
+        [TestCase(RegionEuLr3, 1)]
+        public void GetDataItem_RegionIdAboveOneNibble_IsParsed(byte region, byte channel)
+        {
+            var dataItem = Parse(region, channel);
+
+            Assert.AreEqual(region, dataItem.Frequency);
+            Assert.AreEqual(SpeedLr, dataItem.Speed);
+        }
+
+        [TestCase(RegionEu, 0, Speed100K)]
+        [TestCase(RegionEu, 1, Speed40K)]
+        [TestCase(RegionEu, 2, Speed9600)]
+        [TestCase(RegionUsLr3, 1, SpeedLr)]
+        [TestCase(RegionEuLr1, 3, SpeedLr)]
+        public void GetDataItem_RegionIdWithinOneNibble_IsParsed(byte region, byte channel, byte speed)
+        {
+            var dataItem = Parse(region, channel);
+
+            Assert.AreEqual(region, dataItem.Frequency);
+            Assert.AreEqual(speed, dataItem.Speed);
+        }
+    }
+}

--- a/Tests/ZnifferApplicationTests/ZnifferApplicationTests.csproj
+++ b/Tests/ZnifferApplicationTests/ZnifferApplicationTests.csproj
@@ -40,6 +40,7 @@
     <Compile Include="DataItemTests.cs" />
     <Compile Include="FrameLayerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="PtiFrameParserTests.cs" />
     <Compile Include="S2DecodingTest.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/ZnifferApplication/Parsers/PtiFrameParser.cs
+++ b/ZnifferApplication/Parsers/PtiFrameParser.cs
@@ -24,7 +24,8 @@ namespace ZWave.ZnifferApplication
 
         private static bool tmp = false;
         private static readonly int LengthIndexInHeader = 7;
-        private static readonly byte RegionIdMask = 0x0F;
+        // Region IDs up to EU_LR3 (0x11) need 5 bits
+        private static readonly byte RegionIdMask = 0x1F;
         private static readonly byte ChannelMask = 0x0F;
         private static readonly byte ProtocolMask = 0x0F;
         private static readonly byte ZWaveProtocol = 0x06;
@@ -38,8 +39,8 @@ namespace ZWave.ZnifferApplication
 
         /*
          * In these byte array we are storing information about the available frequencies which is presented
-         * in the ITU-T G.9959 specification (table A.1, A.2). The high nible stores the channel number and the
-         * low nible stores the region ID which can be found in the rail_zwave.h e.g RAIL_ZWAVE_REGIONID_EU.
+         * in the ITU-T G.9959 specification (table A.1, A.2). The high byte stores the channel number and the
+         * low byte stores the region ID which can be found in the rail_zwave.h e.g RAIL_ZWAVE_REGIONID_EU.
          */
         private static readonly ushort[] ChannelRegionsBaudLR = new ushort[]
         {


### PR DESCRIPTION
<!--
  This is a reminder that all Z-Wave Alliance activities are subject to strict
  compliance with the Z-Wave Antitrust Policy and IPR Policy.
  Each individual contributor is responsible to know the contents of these documents
  and to comply with Policies. Copies of all governing documents are available on the SDO member portal.

  Please, DO NOT DELETE ANY TEXT from this template unless instructed!
-->

## Related Issue

Fixes #90

## Change

`PtiFrameParser.RegionIdMask` was `0x0F`, but the region IDs of EU_LR2 (`0x10`) and EU_LR3 (`0x11`) need 5 bits. Bit 4 was dropped, so the frame was looked up under the wrong (RAIL) channel/region key and got the wrong speed:

* EU_LR2 became region `0x00`, which matches no entry. The speed stayed at the 9.6 kbit/s default, and the frame was parsed as a classic frame with a 1 byte CRC, failing the CRC check.
* EU_LR3 became region `0x01`, which is classic EU. Channel 0 gave 100 kbit/s and channel 1 gave 40 kbit/s, again with the classic header base and CRC width.

The mask is now `0x1F`. `dataItem.Frequency` also carries the full region ID again, which decides the header base for Japan and Korea.

There was no test for the region and speed lookup. `PtiFrameParserTests` adds eight cases: the three long range channel/region pairs above one nibble, which fail against the previous mask, and five pairs that already worked.

While in the file, the comment above the lookup tables said the high and low nibble of a key hold the channel and the region. They are the high and low byte.

## Type of change
<!--
  What type of change does your PR introduce?
-->

- [ ] New feature (`feat`)
- [x] Bug fix (`fix`)
- [ ] Editorial change (`chore`, `docs`, `style`, etc.)
- [ ] Refactoring (`refactor`)
- [ ] DevOps (`chore`)
- [ ] Continuous integration (`ci`)
- [ ] Breaking (`!`, `BREAKING CHANGE`)
- [ ] Other (`build`, `perf`, `test`, etc.): (please describe)


## Checklist
<!--
  Please put an `x` in each box to make sure you follow the OSWG Guidelines.
-->

- [x] I have followed the [Contribution Guidelines][contribution-guidelines]
- [x] I agree to the [Developer Certificate of Origin][dco]

This PR is intended for:
- [x] Rebasing – I have cleaned up my commits.
- [ ] Squashing – The squash message should be: 
    ```
    (please describe)
    ```

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/CONTRIBUTING.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
