### PR TITLE
feat: Detect J-Link serial numbers on Windows and Linux alike

### DIFF
--- a/Tests/UtilsTests/JLinkBoardLocatorTests.cs
+++ b/Tests/UtilsTests/JLinkBoardLocatorTests.cs
@@ -1,0 +1,309 @@
+/// SPDX-License-Identifier: BSD-3-Clause
+/// SPDX-FileCopyrightText: Z-Wave-Alliance https://z-wavealliance.org
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Utils;
+#if NETCOREAPP
+using System.IO;
+#endif
+
+namespace UtilsTests
+{
+    /// <summary>
+    /// Covers the J-Link (Gamma board) serial number lookup. The WMI and sysfs queries themselves
+    /// need real hardware, so the platform back ends feed their raw results into the pure helpers
+    /// exercised here.
+    /// </summary>
+    [TestFixture]
+    public class JLinkBoardLocatorTests
+    {
+        // Win32_USBControllerDevice reports its Dependent as a WMI object path in which the
+        // DeviceID separators are doubled.
+        private const string CompositeParent = @"USB\\VID_1366&PID_0105\\000440244321";
+        private const string CompositeInterface = @"USB\\VID_1366&PID_0105&MI_00\\6&2f1a3b4c&0&0000";
+        private const string WinUsbParent = @"USB\\VID_1366&PID_1024\\000440244322";
+        private const string WinUsbParentNeighbour = @"USB\\VID_1366&PID_1024\\000440244323";
+
+        // Win32_PnPEntity reports DeviceID with single separators.
+        private const string CompositePortDeviceId = @"USB\VID_1366&PID_0105&MI_00\6&2f1a3b4c&0&0000";
+        private const string WinUsbPortDeviceId = @"USB\VID_1366&PID_1024\000440244322";
+        private const string WinUsbNeighbourPortDeviceId = @"USB\VID_1366&PID_1024\000440244323";
+
+        private static string Dependent(string deviceId)
+        {
+            return @"\\PC\root\cimv2:Win32_PnPEntity.DeviceID=" + "\"" + deviceId + "\"";
+        }
+
+        private static IEnumerable<KeyValuePair<string, string>> PnpEntity(string deviceId, string name)
+        {
+            return new[] { new KeyValuePair<string, string>(deviceId, name) };
+        }
+
+        #region Topology
+
+        [Test]
+        public void BuildTopology_ParentInstanceSegment_BecomesSerialWithoutLeadingZeros()
+        {
+            var topology = JLinkUsbMatcher.BuildTopology(new[] { Dependent(CompositeParent) });
+
+            Assert.AreEqual(1, topology.Count);
+            Assert.IsTrue(topology.ContainsKey("440244321"));
+        }
+
+        [Test]
+        public void BuildTopology_CompositeAdapter_InterfaceAttachedToItsParent()
+        {
+            var topology = JLinkUsbMatcher.BuildTopology(new[]
+            {
+                Dependent(CompositeParent),
+                Dependent(CompositeInterface)
+            });
+
+            Assert.AreEqual(1, topology.Count);
+            CollectionAssert.Contains(topology["440244321"], @"&MI_00\6&2f1a3b4c&0&0000");
+        }
+
+        /// <summary>
+        /// An adapter is reported once per USB controller. The interfaces that follow the repeated
+        /// entry must attach to it and not to whichever adapter happened to be seen last.
+        /// </summary>
+        [Test]
+        public void BuildTopology_ParentReportedTwice_InterfaceAttachesToMostRecentParent()
+        {
+            var topology = JLinkUsbMatcher.BuildTopology(new[]
+            {
+                Dependent(CompositeParent),
+                Dependent(WinUsbParent),
+                Dependent(CompositeParent),
+                Dependent(CompositeInterface)
+            });
+
+            CollectionAssert.Contains(topology["440244321"], @"&MI_00\6&2f1a3b4c&0&0000");
+            CollectionAssert.IsEmpty(topology["440244322"]);
+        }
+
+        [Test]
+        public void BuildTopology_InterfaceBeforeAnyParent_IsIgnored()
+        {
+            var topology = JLinkUsbMatcher.BuildTopology(new[] { Dependent(CompositeInterface) });
+
+            CollectionAssert.IsEmpty(topology);
+        }
+
+        [Test]
+        public void BuildTopology_ForeignVendor_IsIgnored()
+        {
+            var topology = JLinkUsbMatcher.BuildTopology(new[] { Dependent(@"USB\\VID_0403&PID_6001\\A50285BI") });
+
+            CollectionAssert.IsEmpty(topology);
+        }
+
+        #endregion
+
+        #region Matching
+
+        [Test]
+        public void MatchPorts_CompositeAdapter_PortMappedToSerial()
+        {
+            var topology = JLinkUsbMatcher.BuildTopology(new[]
+            {
+                Dependent(CompositeParent),
+                Dependent(CompositeInterface)
+            });
+
+            var result = JLinkUsbMatcher.MatchPorts(topology,
+                PnpEntity(CompositePortDeviceId, "JLink CDC UART Port (COM7)"));
+
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual("COM7", result[0].Item1);
+            Assert.AreEqual("440244321", result[0].Item2);
+        }
+
+        /// <summary>
+        /// EDE-423: with adapter FW 2.0+ and the general USB driver there are no MI_* interfaces,
+        /// so the port has to be matched through the instance segment of the DeviceID.
+        /// </summary>
+        [Test]
+        public void MatchPorts_WinUsbAdapterWithoutInterfaces_PortMappedToSerial()
+        {
+            var topology = JLinkUsbMatcher.BuildTopology(new[] { Dependent(WinUsbParent) });
+
+            var result = JLinkUsbMatcher.MatchPorts(topology,
+                PnpEntity(WinUsbPortDeviceId, "JLink CDC UART Port (COM8)"));
+
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual("COM8", result[0].Item1);
+            Assert.AreEqual("440244322", result[0].Item2);
+        }
+
+        [Test]
+        public void MatchPorts_AdaptersWithConsecutiveSerials_AreNotConfused()
+        {
+            var topology = JLinkUsbMatcher.BuildTopology(new[]
+            {
+                Dependent(WinUsbParent),
+                Dependent(WinUsbParentNeighbour)
+            });
+
+            var result = JLinkUsbMatcher.MatchPorts(topology, new[]
+            {
+                new KeyValuePair<string, string>(WinUsbPortDeviceId, "JLink CDC UART Port (COM8)"),
+                new KeyValuePair<string, string>(WinUsbNeighbourPortDeviceId, "JLink CDC UART Port (COM9)")
+            });
+
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual("440244322", result.Single(x => x.Item1 == "COM8").Item2);
+            Assert.AreEqual("440244323", result.Single(x => x.Item1 == "COM9").Item2);
+        }
+
+        [Test]
+        public void MatchPorts_NonJLinkPort_IsIgnored()
+        {
+            var topology = JLinkUsbMatcher.BuildTopology(new[] { Dependent(WinUsbParent) });
+
+            var result = JLinkUsbMatcher.MatchPorts(topology,
+                PnpEntity(@"USB\VID_0403&PID_6001\A50285BI", "USB Serial Port (COM3)"));
+
+            CollectionAssert.IsEmpty(result);
+        }
+
+        [Test]
+        public void MatchPorts_PortWithoutComNameInLabel_IsIgnored()
+        {
+            var topology = JLinkUsbMatcher.BuildTopology(new[] { Dependent(WinUsbParent) });
+
+            var result = JLinkUsbMatcher.MatchPorts(topology,
+                PnpEntity(WinUsbPortDeviceId, "JLink CDC UART Port"));
+
+            CollectionAssert.IsEmpty(result);
+        }
+
+        /// <summary>
+        /// Adapters without a USB serial string get a Windows generated instance path. That is not a
+        /// serial number, so it must not be handed to the caller through the instance id fallback.
+        /// </summary>
+        [Test]
+        public void MatchPorts_AdapterWithoutUsbSerial_InstancePathIsNotReportedAsSerial()
+        {
+            var topology = JLinkUsbMatcher.BuildTopology(new[] { Dependent(@"USB\\VID_1366&PID_1024\\6&1a2b3c4d&0&2") });
+
+            var result = JLinkUsbMatcher.MatchPorts(topology,
+                PnpEntity(@"USB\VID_1366&PID_1024\6&1a2b3c4d&0&2", "JLink CDC UART Port (COM8)"));
+
+            CollectionAssert.IsEmpty(result);
+        }
+
+        [Test]
+        public void NormalizeSerial_StripsLeadingZeros()
+        {
+            Assert.AreEqual("440244321", JLinkUsbMatcher.NormalizeSerial("000440244321"));
+            Assert.AreEqual("440244321", JLinkUsbMatcher.NormalizeSerial(" 000440244321 "));
+            Assert.IsNull(JLinkUsbMatcher.NormalizeSerial("0000"));
+            Assert.IsNull(JLinkUsbMatcher.NormalizeSerial(null));
+        }
+
+        #endregion
+
+#if NETCOREAPP
+
+        #region Linux sysfs
+
+        /// <summary>
+        /// Builds a sysfs stand-in. The tty "device" entry is a plain directory rather than a
+        /// symlink so the fixture needs no elevated rights; the attributes sit on its parent, which
+        /// is what the scan walks up to on a real system.
+        /// </summary>
+        private static string CreateSysfsFixture(string tty, string vendorId, string productId, string serial)
+        {
+            var root = Path.Combine(Path.GetTempPath(), "zwtc-sysfs-" + Path.GetRandomFileName());
+            var ttyDirectory = Path.Combine(root, tty);
+            Directory.CreateDirectory(Path.Combine(ttyDirectory, "device"));
+
+            if (vendorId != null)
+                File.WriteAllText(Path.Combine(ttyDirectory, "idVendor"), vendorId + "\n");
+            if (productId != null)
+                File.WriteAllText(Path.Combine(ttyDirectory, "idProduct"), productId + "\n");
+            if (serial != null)
+                File.WriteAllText(Path.Combine(ttyDirectory, "serial"), serial + "\n");
+
+            return root;
+        }
+
+        [Test]
+        public void Scan_JLinkWinUsbAdapter_ReturnsDeviceNodeAndSerial()
+        {
+            var root = CreateSysfsFixture("ttyACM0", "1366", "1024", "000440244322");
+            try
+            {
+                var result = JLinkBoardLocatorUnix.Scan(root, "/dev");
+
+                Assert.AreEqual(1, result.Count);
+                Assert.AreEqual("/dev/ttyACM0", result[0].Item1);
+                Assert.AreEqual("440244322", result[0].Item2);
+            }
+            finally
+            {
+                Directory.Delete(root, true);
+            }
+        }
+
+        [Test]
+        public void Scan_JLinkLegacyAdapter_ReturnsDeviceNodeAndSerial()
+        {
+            var root = CreateSysfsFixture("ttyACM1", "1366", "0105", "000440244321");
+            try
+            {
+                var result = JLinkBoardLocatorUnix.Scan(root, "/dev");
+
+                Assert.AreEqual(1, result.Count);
+                Assert.AreEqual("/dev/ttyACM1", result[0].Item1);
+                Assert.AreEqual("440244321", result[0].Item2);
+            }
+            finally
+            {
+                Directory.Delete(root, true);
+            }
+        }
+
+        [Test]
+        public void Scan_ForeignVendor_IsIgnored()
+        {
+            var root = CreateSysfsFixture("ttyUSB0", "0403", "6001", "A50285BI");
+            try
+            {
+                CollectionAssert.IsEmpty(JLinkBoardLocatorUnix.Scan(root, "/dev"));
+            }
+            finally
+            {
+                Directory.Delete(root, true);
+            }
+        }
+
+        [Test]
+        public void Scan_JLinkWithoutSerialAttribute_IsIgnored()
+        {
+            var root = CreateSysfsFixture("ttyACM0", "1366", "1024", null);
+            try
+            {
+                CollectionAssert.IsEmpty(JLinkBoardLocatorUnix.Scan(root, "/dev"));
+            }
+            finally
+            {
+                Directory.Delete(root, true);
+            }
+        }
+
+        [Test]
+        public void Scan_MissingSysfsRoot_ReturnsEmptyList()
+        {
+            var result = JLinkBoardLocatorUnix.Scan(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()), "/dev");
+
+            CollectionAssert.IsEmpty(result);
+        }
+
+        #endregion
+
+#endif
+    }
+}

--- a/Tests/UtilsTests/UtilsTests.csproj
+++ b/Tests/UtilsTests/UtilsTests.csproj
@@ -45,6 +45,7 @@
     <Compile Include="ConsumerQueueTests.cs" />
     <Compile Include="ConversionTests.cs" />
     <Compile Include="EnumExtensionsTests.cs" />
+    <Compile Include="JLinkBoardLocatorTests.cs" />
     <Compile Include="Int128Tests.cs" />
     <Compile Include="ItemRefTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Utils/JLink/JLinkBoardLocator.cs
+++ b/Utils/JLink/JLinkBoardLocator.cs
@@ -1,0 +1,42 @@
+/// SPDX-License-Identifier: BSD-3-Clause
+/// SPDX-FileCopyrightText: Z-Wave-Alliance https://z-wavealliance.org
+using System;
+using System.Collections.Generic;
+
+namespace Utils
+{
+    /// <summary>
+    /// Maps the serial port of every connected SEGGER J-Link adapter (Gamma board) to its
+    /// J-Link serial number.
+    ///
+    /// Windows reads the USB topology from WMI, Linux/macOS read it from sysfs. Both back ends
+    /// report the canonical J-Link serial number, i.e. the USB serial string without its leading
+    /// zeros ("000440244321" is reported as "440244321"), and the port name in the form the rest
+    /// of the library uses for the platform ("COM7" on Windows, "/dev/ttyACM0" on Linux).
+    /// </summary>
+    public static class JLinkBoardLocator
+    {
+        /// <summary>
+        /// Returns (port name, J-Link serial number) for every connected adapter.
+        /// Never throws - an empty list means nothing was detected.
+        /// </summary>
+        public static List<Tuple<string, string>> GetBoardLinks()
+        {
+            try
+            {
+#if NETCOREAPP
+                return OperatingSystem.IsWindows()
+                    ? JLinkBoardLocatorWindows.GetBoardLinks()
+                    : JLinkBoardLocatorUnix.GetBoardLinks();
+#else
+                return JLinkBoardLocatorWindows.GetBoardLinks();
+#endif
+            }
+            catch (Exception ex)
+            {
+                "JLinkBoardLocator.GetBoardLinks error: {0}"._DLOG(ex.Message);
+                return new List<Tuple<string, string>>();
+            }
+        }
+    }
+}

--- a/Utils/JLink/JLinkBoardLocatorUnix.cs
+++ b/Utils/JLink/JLinkBoardLocatorUnix.cs
@@ -1,0 +1,119 @@
+/// SPDX-License-Identifier: BSD-3-Clause
+/// SPDX-FileCopyrightText: Z-Wave-Alliance https://z-wavealliance.org
+using System;
+using System.Collections.Generic;
+#if NETCOREAPP
+using System.IO;
+using System.Linq;
+#endif
+
+namespace Utils
+{
+#if NETCOREAPP
+    /// <summary>
+    /// Linux/macOS back end of <see cref="JLinkBoardLocator"/>.
+    ///
+    /// There is no WMI, so the USB topology is read from sysfs: every serial port under
+    /// /sys/class/tty has a "device" link into the USB interface it belongs to, and the
+    /// idVendor/idProduct/serial attributes live on the USB device above that interface.
+    /// Reading sysfs directly keeps this free of udev/JLinkExe and needs no extra privileges.
+    /// </summary>
+    internal static class JLinkBoardLocatorUnix
+    {
+        private const string SysfsTtyRoot = "/sys/class/tty";
+        private const string DeviceRoot = "/dev";
+        private const string JLinkVendorId = "1366";
+
+        /// <summary>Product ids of a SEGGER J-Link, matching <see cref="JLinkUsbMatcher.VidPids"/>.</summary>
+        private static readonly string[] JLinkProductIds = new[] { "0105", "1024" };
+
+        /// <summary>A tty hangs off a USB interface; walking up a few levels always reaches the device.</summary>
+        private const int MaxParentWalk = 8;
+
+        internal static List<Tuple<string, string>> GetBoardLinks()
+        {
+            return Scan(SysfsTtyRoot, DeviceRoot);
+        }
+
+        /// <summary>
+        /// Scans a sysfs tty tree. The roots are parameters so the scan can be unit tested
+        /// against a fixture directory.
+        /// </summary>
+        internal static List<Tuple<string, string>> Scan(string sysfsTtyRoot, string deviceRoot)
+        {
+            var ret = new List<Tuple<string, string>>();
+            if (string.IsNullOrEmpty(sysfsTtyRoot) || !Directory.Exists(sysfsTtyRoot))
+                return ret;
+
+            foreach (var ttyDirectory in Directory.EnumerateDirectories(sysfsTtyRoot))
+            {
+                try
+                {
+                    var usbDevice = FindUsbDeviceDirectory(Path.Combine(ttyDirectory, "device"));
+                    if (usbDevice == null)
+                        continue;
+
+                    if (!string.Equals(ReadAttribute(usbDevice, "idVendor"), JLinkVendorId, StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    var productId = ReadAttribute(usbDevice, "idProduct");
+                    if (productId == null || !JLinkProductIds.Contains(productId, StringComparer.OrdinalIgnoreCase))
+                        continue;
+
+                    var serial = JLinkUsbMatcher.NormalizeSerial(ReadAttribute(usbDevice, "serial"));
+                    if (serial == null)
+                        continue;
+
+                    // Device nodes are always "/dev/<name>", independent of the host this runs on.
+                    var portName = deviceRoot.TrimEnd('/') + "/" + Path.GetFileName(ttyDirectory);
+                    ret.Add(new Tuple<string, string>(portName, serial));
+                }
+                catch (Exception ex)
+                {
+                    "JLinkBoardLocatorUnix error for {0}: {1}"._DLOG(ttyDirectory, ex.Message);
+                }
+            }
+
+            return ret;
+        }
+
+        /// <summary>
+        /// Resolves the tty "device" link and walks up until the USB device carrying the
+        /// idVendor/idProduct/serial attributes is reached.
+        /// </summary>
+        private static string FindUsbDeviceDirectory(string deviceLink)
+        {
+            var current = ResolveDirectory(deviceLink);
+            for (int depth = 0; current != null && depth < MaxParentWalk; depth++)
+            {
+                if (File.Exists(Path.Combine(current, "idVendor")))
+                    return current;
+
+                current = Path.GetDirectoryName(current);
+            }
+
+            return null;
+        }
+
+        private static string ResolveDirectory(string path)
+        {
+            if (!Directory.Exists(path))
+                return null;
+
+            // Returns null when the path is a plain directory rather than a symlink.
+            var target = Directory.ResolveLinkTarget(path, returnFinalTarget: true);
+            return target != null ? target.FullName : Path.GetFullPath(path);
+        }
+
+        private static string ReadAttribute(string directory, string attribute)
+        {
+            var file = Path.Combine(directory, attribute);
+            if (!File.Exists(file))
+                return null;
+
+            var value = File.ReadAllText(file).Trim();
+            return value.Length == 0 ? null : value;
+        }
+    }
+#endif
+}

--- a/Utils/JLink/JLinkBoardLocatorWindows.cs
+++ b/Utils/JLink/JLinkBoardLocatorWindows.cs
@@ -1,0 +1,82 @@
+/// SPDX-License-Identifier: BSD-3-Clause
+/// SPDX-FileCopyrightText: Z-Wave-Alliance https://z-wavealliance.org
+using System;
+using System.Collections.Generic;
+using System.Management;
+#if NETCOREAPP
+using System.Runtime.Versioning;
+#endif
+
+namespace Utils
+{
+    /// <summary>
+    /// Windows back end of <see cref="JLinkBoardLocator"/>. Reads the USB topology from WMI.
+    /// Must only be called on Windows - see <see cref="JLinkBoardLocator.GetBoardLinks"/>.
+    /// </summary>
+#if NETCOREAPP
+    [SupportedOSPlatform("windows")]
+#endif
+    internal static class JLinkBoardLocatorWindows
+    {
+        private const string Scope = @"root\CIMV2";
+        private const string UsbControllerDeviceQuery = @"SELECT * FROM Win32_USBControllerDevice";
+        private const string SerialPortEntityQuery =
+            @"SELECT * FROM Win32_PnPEntity WHERE ClassGuid = '{4D36E978-E325-11CE-BFC1-08002BE10318}'";
+
+        internal static List<Tuple<string, string>> GetBoardLinks()
+        {
+            var topology = JLinkUsbMatcher.BuildTopology(QueryUsbControllerDevices());
+            return JLinkUsbMatcher.MatchPorts(topology, QuerySerialPortEntities());
+        }
+
+        private static List<string> QueryUsbControllerDevices()
+        {
+            var ret = new List<string>();
+            using (var searcher = new ManagementObjectSearcher(Scope, UsbControllerDeviceQuery))
+            {
+                try
+                {
+                    foreach (ManagementObject queryObj in searcher.Get())
+                    {
+                        using (queryObj)
+                        {
+                            ret.Add(queryObj.GetPropertyValue("Dependent") as string);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    "JLinkBoardLocatorWindows Win32_USBControllerDevice error: {0}"._DLOG(ex.Message);
+                }
+            }
+
+            return ret;
+        }
+
+        private static List<KeyValuePair<string, string>> QuerySerialPortEntities()
+        {
+            var ret = new List<KeyValuePair<string, string>>();
+            using (var searcher = new ManagementObjectSearcher(Scope, SerialPortEntityQuery))
+            {
+                try
+                {
+                    foreach (ManagementObject queryObj in searcher.Get())
+                    {
+                        using (queryObj)
+                        {
+                            ret.Add(new KeyValuePair<string, string>(
+                                queryObj.GetPropertyValue("DeviceID") as string,
+                                queryObj.GetPropertyValue("Name") as string));
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    "JLinkBoardLocatorWindows Win32_PnPEntity error: {0}"._DLOG(ex.Message);
+                }
+            }
+
+            return ret;
+        }
+    }
+}

--- a/Utils/JLink/JLinkUsbMatcher.cs
+++ b/Utils/JLink/JLinkUsbMatcher.cs
@@ -1,0 +1,157 @@
+/// SPDX-License-Identifier: BSD-3-Clause
+/// SPDX-FileCopyrightText: Z-Wave-Alliance https://z-wavealliance.org
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Utils
+{
+    /// <summary>
+    /// Pure matching logic shared by the platform specific J-Link board locators.
+    /// Kept free of WMI and file system access so that it can be unit tested.
+    /// </summary>
+    internal static class JLinkUsbMatcher
+    {
+        /// <summary>USB VID/PID pairs a SEGGER J-Link adapter can enumerate as.</summary>
+        internal static readonly string[] VidPids = new[]
+        {
+            @"VID_1366&PID_0105",   // SEGGER legacy driver "JLink CDC UART Port"
+            @"VID_1366&PID_1024"    // WinUSB / general USB driver (adapter FW 2.0+)
+        };
+
+        /// <summary>
+        /// Turns the USB serial string into the canonical J-Link serial number.
+        /// The USB descriptor zero pads the number (e.g. "000440244321" for SN 440244321).
+        /// </summary>
+        internal static string NormalizeSerial(string usbSerial)
+        {
+            if (string.IsNullOrEmpty(usbSerial))
+                return null;
+
+            var trimmed = usbSerial.Trim().TrimStart('0');
+            return trimmed.Length == 0 ? null : trimmed;
+        }
+
+        /// <summary>
+        /// True when the value can be a J-Link serial number rather than a Windows generated
+        /// instance path such as "6&amp;2f1a3b4c&amp;0&amp;2" (adapters without a USB serial string).
+        /// </summary>
+        internal static bool LooksLikeSerialNumber(string candidate)
+        {
+            return !string.IsNullOrEmpty(candidate) && candidate.All(char.IsDigit);
+        }
+
+        /// <summary>
+        /// Builds a "serial number -&gt; child interface instance ids" map from the Dependent
+        /// strings of Win32_USBControllerDevice.
+        /// </summary>
+        internal static Dictionary<string, List<string>> BuildTopology(IEnumerable<string> dependents)
+        {
+            var topology = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+            if (dependents == null)
+                return topology;
+
+            string lastId = null;
+            foreach (var dependent in dependents)
+            {
+                if (string.IsNullOrEmpty(dependent))
+                    continue;
+
+                foreach (var vidPid in VidPids)
+                {
+                    int inx = dependent.IndexOf(vidPid, StringComparison.OrdinalIgnoreCase);
+                    if (inx < 0)
+                        continue;
+
+                    string id = dependent.Substring(inx + vidPid.Length).Replace(@"\\", @"\").Trim('\\', '"');
+                    if (id.Length > 0)
+                    {
+                        if (id.StartsWith("&", StringComparison.Ordinal))
+                        {
+                            // An interface of the composite parent seen before, e.g. "&MI_00\6&2f1a3b4c&0&0000".
+                            if (lastId != null && topology.ContainsKey(lastId))
+                                topology[lastId].Add(id);
+                        }
+                        else
+                        {
+                            // A parent device - its instance segment carries the serial number.
+                            id = id.TrimStart('0');
+                            if (id.Length > 0)
+                            {
+                                if (!topology.ContainsKey(id))
+                                    topology.Add(id, new List<string>());
+
+                                // Always track the most recent parent, so its interfaces attach here even
+                                // when the same adapter is reported twice (once per USB controller).
+                                lastId = id;
+                            }
+                        }
+                    }
+
+                    // A Dependent can only ever carry one of the VID/PID pairs.
+                    break;
+                }
+            }
+
+            return topology;
+        }
+
+        /// <summary>
+        /// Matches serial ports against the USB topology.
+        /// </summary>
+        /// <param name="topology">Result of <see cref="BuildTopology"/>.</param>
+        /// <param name="serialPortEntities">Win32_PnPEntity DeviceID -&gt; Name pairs of the Ports class.</param>
+        internal static List<Tuple<string, string>> MatchPorts(
+            Dictionary<string, List<string>> topology,
+            IEnumerable<KeyValuePair<string, string>> serialPortEntities)
+        {
+            var ret = new List<Tuple<string, string>>();
+            if (topology == null || topology.Count == 0 || serialPortEntities == null)
+                return ret;
+
+            foreach (var entity in serialPortEntities)
+            {
+                var deviceId = entity.Key;
+                var name = entity.Value;
+                if (string.IsNullOrEmpty(deviceId) || string.IsNullOrEmpty(name))
+                    continue;
+
+                if (!VidPids.Any(x => deviceId.IndexOf(x, StringComparison.OrdinalIgnoreCase) >= 0))
+                    continue;
+
+                var port = name.Split('(', ')').FirstOrDefault(x => x.StartsWith("COM", StringComparison.Ordinal));
+                if (port == null)
+                    continue;
+
+                // The instance id is the last '\'-separated segment of the DeviceID: "000440244321"
+                // for a WinUSB adapter, "6&2f1a3b4c&0&0000" for a composite PID_0105 interface.
+                int lastSep = deviceId.LastIndexOf('\\');
+                var instanceId = lastSep >= 0 ? deviceId.Substring(lastSep + 1) : deviceId;
+                var normalizedInstanceId = instanceId.TrimStart('0');
+
+                foreach (var record in topology)
+                {
+                    bool matched = record.Value.Any(child => deviceId.IndexOf(child, StringComparison.OrdinalIgnoreCase) >= 0);
+
+                    // WinUSB (PID_1024) adapters expose no MI_* interfaces, so compare the instance
+                    // segment itself. It is compared in full - a prefix match would confuse adapters
+                    // whose serial numbers only differ in the last digits.
+                    if (!matched
+                        && LooksLikeSerialNumber(record.Key)
+                        && string.Equals(normalizedInstanceId, record.Key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        matched = true;
+                    }
+
+                    if (matched)
+                    {
+                        ret.Add(new Tuple<string, string>(port, record.Key));
+                        break;
+                    }
+                }
+            }
+
+            return ret;
+        }
+    }
+}

--- a/Utils/Properties/AssemblyInfo.cs
+++ b/Utils/Properties/AssemblyInfo.cs
@@ -1,7 +1,8 @@
-/// SPDX-License-Identifier: BSD-3-Clause
+﻿/// SPDX-License-Identifier: BSD-3-Clause
 /// SPDX-FileCopyrightText: Silicon Laboratories Inc. https://www.silabs.com
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -35,3 +36,6 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("5.48")]
 //[assembly: AssemblyFileVersion("2.03")]
+
+// The J-Link board locator internals are unit tested from UtilsTests.
+[assembly: InternalsVisibleTo("UtilsTests")]

--- a/Utils/Utils.csproj
+++ b/Utils/Utils.csproj
@@ -78,6 +78,10 @@
     <Compile Include="UI\Logging\LogSettings.cs" />
     <Compile Include="UI\NotifyCommandData.cs" />
     <Compile Include="UI\Wrappers\SelectableItem.cs" />
+    <Compile Include="JLink\JLinkBoardLocator.cs" />
+    <Compile Include="JLink\JLinkBoardLocatorUnix.cs" />
+    <Compile Include="JLink\JLinkBoardLocatorWindows.cs" />
+    <Compile Include="JLink\JLinkUsbMatcher.cs" />
     <Compile Include="WinBased\SerialPortMontiorHelper.cs" />
     <Compile Include="WinBased\ComputerSystemHardwareHelper.cs" />
     <Compile Include="SizeLimitedTable.cs" />

--- a/Utils/Utils_netcore.csproj
+++ b/Utils/Utils_netcore.csproj
@@ -7,9 +7,14 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
     <!-- for .NET (Core) -->
+    <!-- WinBased holds Windows only WMI/registry helpers and stays out of the .NET (Core) build.
+         The J-Link board lookup under JLink/ is cross platform and is compiled for every target. -->
     <Compile Remove="WinBased\**" />
     <PackageReference Include="System.IO.Ports" Version="8.0.0" />
     <PackageReference Include="System.IO.Packaging" Version="10.0.2" />
+    <!-- Windows only at run time, but restores and publishes for every RID (incl. linux-x64).
+         JLinkBoardLocator guards every call with OperatingSystem.IsWindows(). -->
+    <PackageReference Include="System.Management" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
     <!-- for .NET Framework 4.8 -->

--- a/Utils/WinBased/ComputerSystemHardwareHelper.cs
+++ b/Utils/WinBased/ComputerSystemHardwareHelper.cs
@@ -70,106 +70,17 @@ namespace Utils
             }
         }
 
+        /// <summary>
+        /// Returns (port name, J-Link serial number) for every connected Gamma board.
+        /// </summary>
+        /// <remarks>
+        /// Retained for the .NET Framework callers of this class. The implementation lives in
+        /// <see cref="JLinkBoardLocator"/> so that .NET (Core) consumers - which do not compile
+        /// this Windows only file - share the very same matching logic on Windows and Linux.
+        /// </remarks>
         public static List<Tuple<string, string>> GetGammaSourceAndSerial()
         {
-            var vidPids = new List<string>()
-            {
-                @"VID_1366&PID_0105",   // SEGGER legacy driver "JLink CDC UART Port"
-                @"VID_1366&PID_1024"    // WinUSB driver
-            };
-            Dictionary<string, List<string>> tmp = new Dictionary<string, List<string>>();
-            List<Tuple<string, string>> ret = new List<Tuple<string, string>>();
-            ManagementObjectSearcher searcher = new ManagementObjectSearcher(
-                    "root\\CIMV2",
-                    @"SELECT * FROM Win32_USBControllerDevice");
-            try
-            {
-                string lastId = "";
-                foreach (ManagementObject queryObj in searcher.Get())
-                {
-                    try
-                    {
-                        var dependent = queryObj.GetPropertyValue("Dependent") as string;
-                        if (dependent != null)
-                        {
-                            foreach (string vidPid in vidPids)
-                            {
-                                if (dependent.Contains(vidPid))
-                                {
-                                    string id = dependent.Substring(dependent.IndexOf(vidPid) + vidPid.Length).Replace(@"\\", @"\");
-                                    id = id.Trim('\\', '\"');
-                                    if (!id.StartsWith("&"))
-                                    {
-                                        id = id.TrimStart('0');
-                                        if (!tmp.ContainsKey(id))
-                                        {
-                                            tmp.Add(id, new List<string>());
-                                            lastId = id;
-                                        }
-                                    }
-                                    else
-                                    {
-                                        tmp[lastId].Add(id);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    catch (Exception) { }
-                }
-            }
-            catch (ManagementException) { }
-            finally
-            {
-                searcher.Dispose();
-            }
-
-            searcher = new ManagementObjectSearcher(
-                  "root\\CIMV2",
-                  @"SELECT * FROM Win32_PnPEntity WHERE ClassGuid = '{4D36E978-E325-11CE-BFC1-08002BE10318}'");
-            try
-            {
-                foreach (ManagementObject queryObj in searcher.Get())
-                {
-                    var deviceId = queryObj.GetPropertyValue("DeviceID") as string;
-                    if (deviceId != null)
-                    {
-                        foreach (string vidPid in vidPids)
-                        {
-                            if (deviceId.Contains(vidPid))
-                            {
-                                var name = queryObj.GetPropertyValue("Name") as string;
-                                if (name != null)
-                                {
-                                    var port = name.Split('(', ')').FirstOrDefault(x => x.StartsWith("COM"));
-                                    if (port != null)
-                                    {
-                                        foreach (var record in tmp)
-                                        {
-                                            foreach (var item in record.Value)
-                                            {
-                                                if (deviceId.Contains(item))
-                                                {
-                                                    ret.Add(new Tuple<string, string>(port, record.Key));
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-
-                        }
-                    }
-                }
-            }
-            catch (ManagementException) { }
-            finally
-            {
-                searcher.Dispose();
-            }
-
-
-            return ret;
+            return JLinkBoardLocator.GetBoardLinks();
         }
 
         private static void GetRelated(string indent, ManagementObject obj, string selfId)


### PR DESCRIPTION
<!--
SPDX-License-Identifier: BSD-3-Clause
SPDX-FileCopyrightText: Z-Wave Alliance <https://z-wavealliance.org>
-->

<!--
  This is a reminder that all Z-Wave Alliance activities are subject to strict
  compliance with the Z-Wave Antitrust Policy and IPR Policy.
  Each individual contributor is responsible to know the contents of these documents
  and to comply with Policies. Copies of all governing documents are available on the SDO member portal.

  Please, DO NOT DELETE ANY TEXT from this template unless instructed!
-->

## Related Issue
<!--
  Mention the related issue as described in https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword.
-->

https://mk-logic.atlassian.net/browse/EDE-423

## Change
<!--
  Describe your changes below.
-->

feat: Detect J-Link serial numbers on Windows and Linux alike

GetGammaSourceAndSerial lived in WinBased/, which is excluded from the
.NET (Core) build, so the J-Link serial lookup was reachable only from
.NET Framework. .NET consumers had to carry their own copy - EDE forked
one that never learned about the PID_1024 adapters - and none of them
worked on Linux at all.

Move the lookup into Utils/JLink/, compiled for every target framework,
and dispatch on the running platform the way SerialPortProvider already
does:

* JLinkUsbMatcher holds the matching logic, free of WMI and file access.
* JLinkBoardLocatorWindows feeds it the Win32_USBControllerDevice and
  Win32_PnPEntity results.
* JLinkBoardLocatorUnix reads the USB topology from sysfs, walking from
  /sys/class/tty/<port>/device up to the USB device that carries
  idVendor, idProduct and serial. No udev, no JLinkExe, no privileges.
* JLinkBoardLocator picks the back end and never throws.

Both back ends report the canonical J-Link serial number, that is the
USB serial string without its leading zeros, so the value matches what
the JLinkExe based detection in ZATS returns.

A net10.0-windows target framework would not have helped the consumer
that needs this most: EDE's EmulatorBase is plain net10.0 because it is
shared between the WPF frontend and the backend published for linux-x64.

Adapters with FW 2.0+ on the general USB driver enumerate as PID_1024
without MI_* interfaces, so their port is matched through the instance
segment of the DeviceID. It is compared in full - a prefix match would
confuse adapters whose serial numbers differ only in the last digits -
and only when it looks like a serial number, so that the instance path
of an adapter without a USB serial string is not reported as one. The
parent is now tracked on every occurrence as well, because an adapter is
listed once per USB controller and its interfaces used to attach to
whichever adapter happened to be seen last.

WinBased/ keeps its Windows only WMI and registry helpers and stays out
of the .NET (Core) build. ComputerSystemHardwareHelper.GetGammaSourceAndSerial
delegates to the shared implementation, so the .NET Framework callers in
ZATS and CTT are unaffected. The .NET (Core) build gains a
System.Management reference, which restores and publishes for every RID
including linux-x64.

JLinkBoardLocatorTests covers both back ends: the PID_1024 case, the
composite PID_0105 case, adapters with consecutive serial numbers, the
repeated parent entry and the sysfs scan against a fixture tree.

Relates to: https://mk-logic.atlassian.net/browse/EDE-423

## Type of change
<!--
  What type of change does your PR introduce?
-->

- [x] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Editorial change (`chore`, `docs`, `style`, etc.)
- [x] Refactoring (`refactor`)
- [ ] DevOps (`chore`, `ci`)
- [ ] Breaking (`!`, `BREAKING CHANGE`)
- [ ] Other (`build`, `perf`, `test`, etc.): (please describe)


## Checklist
<!--
  Please put an `x` in each box to make sure you follow the OSWG Guidelines.
-->

- [x] I have followed the [Contribution Guidelines][contribution-guidelines]
- [x] I agree to the [Developer Certificate of Origin][dco]

This PR is intended for:
- [x] Rebasing – I have cleaned up my commits.
- [ ] Squashing – The squash message should be: 
    ```
    (please describe)
    ```

[contribution-guidelines]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/CONTRIBUTING.md
[dco]: https://github.com/Z-Wave-Alliance/OSWG/blob/main/developer_certificate_of_origin.md
